### PR TITLE
Install freva from conda

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -13,6 +13,7 @@ dependencies:
   - django-webpack-loader
   - djangorestframework
   - fabric
+  - freva
   - git
   - gunicorn
   - markdown
@@ -38,7 +39,6 @@ dependencies:
     - django-discover-runner
     - django-bootstrap-v5
     - django-model-utils
-    - freva
     - pep257
     - types-requests
     - types-toml


### PR DESCRIPTION
Quick fix. H5py fails when installing it with pip because it can't find hdf5, which doesn't get installed anymore. A simple fix is moving the freva dependency from the pip to the conda section. 