### PR TITLE
UI improvements

### DIFF
--- a/assets/js/Components/AccordionItemBody/index.js
+++ b/assets/js/Components/AccordionItemBody/index.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useLayoutEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
-import { FormControl, Tooltip, OverlayTrigger } from "react-bootstrap";
+import { FormControl, Tooltip, OverlayTrigger, Badge } from "react-bootstrap";
 import { VariableSizeList as List } from "react-window";
 
 /**
@@ -107,7 +107,7 @@ function AccordionItemBody(props) {
                 {value}
               </a>
             </OverlayTrigger>{" "}
-            [{count}]
+            <Badge bg="secondary">{count}</Badge>
           </div>
         );
       }
@@ -125,7 +125,7 @@ function AccordionItemBody(props) {
           >
             {value}
           </a>{" "}
-          [{item.count}]
+          <Badge bg="secondary">{item.count}</Badge>
         </div>
       );
     });

--- a/assets/js/Containers/Databrowser/index.js
+++ b/assets/js/Containers/Databrowser/index.js
@@ -10,6 +10,7 @@ import {
   OverlayTrigger,
   Button,
   Alert,
+  Badge,
 } from "react-bootstrap";
 
 import { FaInfoCircle } from "react-icons/fa";
@@ -100,8 +101,9 @@ class Databrowser extends React.Component {
       } else {
         const numberOfValues = value.length / 2;
         panelHeader = (
-          <span>
-            {key} ({numberOfValues})
+          <span className="d-flex justify-content-between">
+            <span>{key}</span>
+            <Badge bg="secondary">{numberOfValues}</Badge>
           </span>
         );
       }
@@ -191,7 +193,10 @@ class Databrowser extends React.Component {
     const { files, numFiles, fileLoading } = this.props.databrowser;
     return (
       <div className="py-3">
-        <h3> Files [{numFiles}]</h3>
+        <h3 className="d-flex justify-content-between">
+          <span>Files</span>
+          <Badge bg="secondary">{numFiles.toLocaleString("en-US")}</Badge>
+        </h3>
         <ul
           className="jqueryFileTree border shadow-sm py-3 rounded"
           style={{ maxHeight: "1000px", overflow: "auto" }}
@@ -211,14 +216,14 @@ class Databrowser extends React.Component {
                   >
                     <Button
                       variant="link"
-                      className="p-0"
+                      className="p-0 me-1"
                       onClick={() => {
                         this.setState({ showDialog: true, fn });
                       }}
                     >
                       <FaInfoCircle className="ncdump" />
                     </Button>
-                  </OverlayTrigger>{" "}
+                  </OverlayTrigger>
                   {fn}
                 </li>
               );

--- a/assets/js/Containers/Resultbrowser/index.js
+++ b/assets/js/Containers/Resultbrowser/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { connect } from "react-redux";
-import { Container, Row, Col, Card, Alert } from "react-bootstrap";
+import { Container, Row, Col, Card, Alert, Badge } from "react-bootstrap";
 
 import _ from "lodash";
 
@@ -176,8 +176,8 @@ class Resultbrowser extends React.Component {
       } else {
         const numberOfValues = value.length / 2;
         panelHeader = (
-          <span>
-            {key} ({numberOfValues})
+          <span className="d-flex justify-content-between">
+            <span>{key}</span> <Badge bg="secondary">{numberOfValues}</Badge>
           </span>
         );
       }


### PR DESCRIPTION
- replaced count-numbers in braces or brackets in Data and Result Browser by badges at the end.

- the number of found results in Data Browser is now formatted

- replaced the whitespace at the beginning of each line of the search results in Data Browser by a margin. This has the effect that selecting a file name by double click will no longer select the unnecessary whitespace at the beginning

![Screenshot from 2023-03-13 09-23-55](https://user-images.githubusercontent.com/11878342/224646423-1365e379-a963-4a7a-9423-1376c20a1842.png)
