### PR TITLE
Fix wrong docs link

### DIFF
--- a/templates/plugins/list-docu.html
+++ b/templates/plugins/list-docu.html
@@ -14,7 +14,7 @@
                 <li><h2 class="fs-5">System documentation</h2></li>
                 <ul>
                     <li>
-                        <a href="https://freva-clint.github.io/freva/Freva.html" class="">
+                        <a href="https://freva-clint.github.io/freva/index.html" class="">
                             Freva-Docs
                         </a>
                     </li>


### PR DESCRIPTION
I realised I had the wrong link pointing to freva docs. This fixes this.