### PR TITLE
Integrade sendgrid API.

### DIFF
--- a/.github/workflows/build_job.yml
+++ b/.github/workflows/build_job.yml
@@ -52,7 +52,9 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
-          build-args: VERSION=${{steps.repository.outputs.tag}}
+          build-args: |
+            VERSION=${{steps.repository.outputs.tag}}
+            EMAIL_HOST_PASSWORD=${{secrets.EMAIL_HOST_PASSWORD}}
           push: true
           tags: |
             ghcr.io/${{ steps.repository.outputs.repo }}:${{ steps.repository.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG CONDA_ENV_DIR=/opt/condaenv
 ARG FREVA_WEB_DIR=/opt/freva_web
+ARG EMAIL_HOST_PASSWORD=""
 ARG VERSION
 
 FROM condaforge/mambaforge
@@ -14,7 +15,8 @@ RUN set -e && \
 WORKDIR ${FREVA_WEB_DIR}
 COPY . .
 ENV PATH=$CONDA_ENV_DIR/bin:$PATH\
-    DJANGO_SUPERUSER_EMAIL=freva@dkrz.de
+    DJANGO_SUPERUSER_EMAIL=freva@dkrz.de\
+    EMAIL_HOST_PASSWORD=$EMAIL_HOST_PASSWORD
 RUN  set -e && \
      mamba env create -y -p ${CONDA_ENV_DIR} -f conda-env.yml &&\
      mamba clean -afy &&\

--- a/django_evaluation/settings/local.py
+++ b/django_evaluation/settings/local.py
@@ -241,17 +241,11 @@ DATA_BROWSER_HOST = os.environ.get("FREVA_REST_URL", "http://localhost:7777")
 SERVER_EMAIL = os.environ.get("SERVER_EMAIL", "freva@dkrz.de")
 DEFAULT_FROM_EMAIL = SERVER_EMAIL
 
-EMAIL_HOST = os.environ.get("EMAIL_HOST", "mailhost.dkrz.de")
-
-EMAIL_PORT = int(os.environ.get("EMAIL_PORT", "25"))
-if EMAIL_PORT == 25:
-    EMAIL_HOST_USER = ""
-    EMAIL_HOST_PASSWORD = ""
-else:
-    email_secrets = _read_secret()
-    EMAIL_HOST_USER = email_secrets.get("username")
-    EMAIL_HOST_PASSWORD = email_secrets.get("password")
-
+EMAIL_HOST = "smtp.sendgrid.net"
+EMAIL_PORT = "587"
+EMAIL_USE_TLS = True
+EMAIL_HOST_USER = "apikey"
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
 
 HOME_DIRS_AVAILABLE = False
 

--- a/django_evaluation/settings/local.py
+++ b/django_evaluation/settings/local.py
@@ -79,17 +79,6 @@ def _get_logo(logo_file, project_root):
     return f"/static/img/{logo_file.name}"
 
 
-def _read_secret(port: int = 5002, key: str = "email") -> dict[str, str]:
-    """Read the key-value pair secrets from vault server."""
-    sha = config._get_public_key(config.get("project_name"))
-    uri = f"http://{config.get('db.host')}:{port}/vault/{key}/{sha}"
-    try:
-        req = requests.get(uri).json()
-    except requests.exceptions.ConnectionError:
-        req = {}
-    return req
-
-
 def _set_favicon(html_color: str, project_root: Path) -> None:
     img_folder = Path(project_root) / "static" / "img"
     tmpl_folder = Path(project_root) / "static_root" / "img"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evaluation_system_web",
-  "version": "2405.0.0",
+  "version": "2408.0.0",
   "description": "React-bits of the freva-web interface. The react-parts of the web interface include the plugin-selection, the data-browser and the result-browser",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
I took the liberty to open a [sendgrid account](https://en.wikipedia.org/wiki/SendGrid). The free plan includes 100 emails per month. I think that's more than enough. On the senders side the mail appears to be sent by freva@dkrz.de.

Since we user docker containers that are built by the CI pipeline, it is fairly straightforward to ship the API key. I created a [new secret](https://github.com/FREVA-CLINT/freva-web/settings/secrets/actions) and use that secret to set the API key as environment variable in the docker container. Then the django code is evaluating this env variable and Bob's your uncle.

@eelucio @ckadow @Karinon  FYI.