### PR TITLE
Draft: adding bbox selector with fully  inspiration from TimeRangeSelector

### DIFF
--- a/assets/js/Containers/Databrowser/BoundingBoxSelector.js
+++ b/assets/js/Containers/Databrowser/BoundingBoxSelector.js
@@ -1,0 +1,171 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import { withRouter } from "react-router";
+import queryString from "query-string";
+import {
+  Button,
+  InputGroup,
+  Form,
+  OverlayTrigger,
+  Tooltip,
+  Row,
+  Col,
+} from "react-bootstrap";
+
+function BoundingBoxSelector({ databrowser, router, location }) {
+  const [minX, setMinX] = useState("-180");
+  const [maxX, setMaxX] = useState("180");
+  const [minY, setMinY] = useState("-90");
+  const [maxY, setMaxY] = useState("90");
+
+  useEffect(() => {
+    if (databrowser.bbox) {
+      const [west, east, north, south] = databrowser.bbox
+        .replace("ENVELOPE(", "")
+        .replace(")", "")
+        .split(", ")
+        .map(Number);
+      setMinX(west.toString());
+      setMaxX(east.toString());
+      setMinY(south.toString());
+      setMaxY(north.toString());
+    }
+  }, [databrowser]);
+
+  function validateCoordinates() {
+    const parsedMinX = parseFloat(minX);
+    const parsedMaxX = parseFloat(maxX);
+    const parsedMinY = parseFloat(minY);
+    const parsedMaxY = parseFloat(maxY);
+
+    if (isNaN(parsedMinX) || isNaN(parsedMaxX) || isNaN(parsedMinY) || isNaN(parsedMaxY)) {
+      return "All coordinates must be valid numbers";
+    }
+
+    if (parsedMinX < -180 || parsedMaxX > 180) {
+      return "Longitude must be between -180 and 180";
+    }
+
+    if (parsedMinY < -90 || parsedMaxY > 90) {
+      return "Latitude must be between -90 and 90";
+    }
+
+    if (parsedMinX >= parsedMaxX) {
+      return "East longitude must be greater than West longitude";
+    }
+
+    if (parsedMinY >= parsedMaxY) {
+      return "North latitude must be greater than South latitude";
+    }
+
+    return "";
+  }
+
+  function applyChanges() {
+    const currentLocation = location.pathname;
+    const { bbox: ignore, ...queryObject } = location.query;
+    
+    const bboxString = `ENVELOPE(${minX}, ${maxX}, ${maxY}, ${minY})`;
+    const query = queryString.stringify({
+      ...queryObject,
+      bbox: bboxString,
+    });
+    
+    router.push(currentLocation + "?" + query);
+  }
+
+  function onKeyPress(errorMessage, e) {
+    const enterKey = 13;
+    if (!errorMessage && e.charCode === enterKey) {
+      applyChanges();
+    }
+  }
+
+  const errorMessage = validateCoordinates();
+  const applyButton = errorMessage ? (
+    <OverlayTrigger overlay={<Tooltip>{errorMessage}</Tooltip>} placement="top">
+      <span>
+        <Button variant="danger" disabled>
+          Apply
+        </Button>
+      </span>
+    </OverlayTrigger>
+  ) : (
+    <Button variant="primary" onClick={applyChanges}>
+      Apply
+    </Button>
+  );
+
+  return (
+    <div onKeyPress={onKeyPress.bind(this, errorMessage)}>
+      <Row className="mb-3">
+        <Col>
+          <InputGroup>
+            <InputGroup.Text>West</InputGroup.Text>
+            <Form.Control
+              type="number"
+              step="0.1"
+              value={minX}
+              onChange={(e) => setMinX(e.target.value)}
+              placeholder="-180"
+            />
+          </InputGroup>
+        </Col>
+        <Col>
+          <InputGroup>
+            <InputGroup.Text>East</InputGroup.Text>
+            <Form.Control
+              type="number"
+              step="0.1"
+              value={maxX}
+              onChange={(e) => setMaxX(e.target.value)}
+              placeholder="180"
+            />
+          </InputGroup>
+        </Col>
+      </Row>
+      <Row className="mb-3">
+        <Col>
+          <InputGroup>
+            <InputGroup.Text>South</InputGroup.Text>
+            <Form.Control
+              type="number"
+              step="0.1"
+              value={minY}
+              onChange={(e) => setMinY(e.target.value)}
+              placeholder="-90"
+            />
+          </InputGroup>
+        </Col>
+        <Col>
+          <InputGroup>
+            <InputGroup.Text>North</InputGroup.Text>
+            <Form.Control
+              type="number"
+              step="0.1"
+              value={maxY}
+              onChange={(e) => setMaxY(e.target.value)}
+              placeholder="90"
+            />
+          </InputGroup>
+        </Col>
+      </Row>
+      <div className="text-danger mb-2">{errorMessage}&nbsp;</div>
+      {applyButton}
+    </div>
+  );
+}
+
+BoundingBoxSelector.propTypes = {
+  databrowser: PropTypes.object,
+  location: PropTypes.object.isRequired,
+  router: PropTypes.object.isRequired,
+  dispatch: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = (state) => ({
+  databrowser: state.databrowserReducer,
+});
+
+export default withRouter(connect(mapStateToProps)(BoundingBoxSelector));

--- a/assets/js/Containers/Databrowser/constants.js
+++ b/assets/js/Containers/Databrowser/constants.js
@@ -15,6 +15,7 @@ export const LOAD_NCDUMP_SUCCESS = "LOAD_NCDUMP_SUCCESS";
 export const LOAD_NCDUMP_ERROR = "LOAD_NCDUMP_ERROR";
 export const RESET_NCDUMP = "RESET_NCDUMP";
 
+export const SET_BBOX = "SET_BBOX";
 export const TIME_RANGE_FLEXIBLE = "flexible";
 export const TIME_RANGE_STRICT = "strict";
 export const TIME_RANGE_FILE = "file";

--- a/assets/js/Containers/Databrowser/index.js
+++ b/assets/js/Containers/Databrowser/index.js
@@ -38,6 +38,7 @@ import {
 } from "./actions";
 
 import TimeRangeSelector from "./TimeRangeSelector";
+import BoundingBoxSelector from './BoundingBoxSelector';
 import FilesPanel from "./FilesPanel";
 import DataBrowserCommand from "./DataBrowserCommand";
 import FacetDropdown from "./MetaFacet";
@@ -200,7 +201,16 @@ class Databrowser extends React.Component {
       this.props.router.push(currentLocation);
     }
   }
-
+  dropBoundingBox() {
+    const currentLocation = this.props.location.pathname;
+    const { bbox: ignore, ...queryObject } = this.props.location.query;
+    const query = queryString.stringify(queryObject);
+    if (query) {
+      this.props.router.push(currentLocation + "?" + query);
+    } else {
+      this.props.router.push(currentLocation);
+    }
+  }
   createIntakeLink() {
     return (
       "/api/freva-nextgen/databrowser/intake-catalogue/" +
@@ -231,7 +241,30 @@ class Databrowser extends React.Component {
       </OwnPanel>
     );
   }
+  renderBoundingBoxPanel() {
+    const { bbox } = this.props.databrowser;
+    const isBboxSelected = !!bbox;
+    const title = isBboxSelected ? (
+      <span>
+        Bounding Box: &nbsp;
+        <span className="fw-bold">
+          {bbox}
+        </span>
+      </span>
+    ) : (
+      <span>Bounding Box</span>
+    );
 
+    return (
+      <OwnPanel
+        header={title}
+        key="bounding_box"
+        removeFacet={isBboxSelected ? () => this.dropBoundingBox() : null}
+      >
+        <BoundingBoxSelector />
+      </OwnPanel>
+    );
+  }
   renderFacetBadges() {
     const { dateSelector, minDate, maxDate } = this.props.databrowser;
     const isDateSelected = !!minDate;
@@ -423,6 +456,7 @@ class Databrowser extends React.Component {
 
             {facetPanels}
             {this.renderTimeSelectionPanel()}
+            {this.renderBoundingBoxPanel()}
             <Button
               className="w-100 mb-3 shadow-sm p-3"
               variant="secondary"
@@ -479,6 +513,7 @@ Databrowser.propTypes = {
     dateSelector: PropTypes.string,
     minDate: PropTypes.string,
     maxDate: PropTypes.string,
+    bbox: PropTypes.string,
   }),
   location: PropTypes.object.isRequired,
   router: PropTypes.object.isRequired,

--- a/assets/js/Containers/Databrowser/reducers.js
+++ b/assets/js/Containers/Databrowser/reducers.js
@@ -14,6 +14,7 @@ const databrowserInitialState = {
   fileLoading: false,
   flavours: ["freva"],
   selectedFlavour: constants.DEFAULT_FLAVOUR,
+  bbox: null,
 };
 
 export const databrowserReducer = (state = databrowserInitialState, action) => {
@@ -28,7 +29,7 @@ export const databrowserReducer = (state = databrowserInitialState, action) => {
         facetLoading: false,
       };
     case constants.UPDATE_FACET_SELECTION: {
-      const { minDate, maxDate, dateSelector, start, flavour, ...queryObject } =
+      const { minDate, maxDate, dateSelector, start, flavour, bbox, ...queryObject } =
         action.queryObject;
       let myMinDate = minDate;
       let myMaxDate = maxDate;
@@ -46,6 +47,7 @@ export const databrowserReducer = (state = databrowserInitialState, action) => {
         minDate: myMinDate,
         maxDate: myMaxDate,
         selectedFlavour: flavour || databrowserInitialState.selectedFlavour,
+        bbox: bbox || databrowserInitialState.bbox,
       };
     }
     case constants.SET_METADATA:
@@ -63,6 +65,7 @@ export const databrowserReducer = (state = databrowserInitialState, action) => {
         fileLoading: false,
         start: parseInt(action.payload.start),
         selectedFlavour: action.payload.flavour,
+        bbox: action.payload.bbox,
       };
     default:
       return state;


### PR DESCRIPTION
This is still the draft version. But generally this PR introduces a new bounding box facet selector as you it's done in TimeRangeSelector. It's **not ready** for review yet, becasue still I'm not sure how we are going to pass the response from freva rest endpoint to front. I assumed we are going to pass bbox as we get from Solr, but still three other PRs have to be done to get here.

It looks like this

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9415bc41-f11d-49e5-aa4a-77a5b04dc5fb">

Having this feature in the Data Browser frontend for exploration purposes feels redundant to me. When you select the Germany bounding box, the global view is also included by default, as both are encompassed in the bounding box filter! But let's see how it goes on and on