### PR TITLE
change fixed height width to be responsive in preview-html.html

### DIFF
--- a/templates/history/templatetags/preview-html.html
+++ b/templates/history/templatetags/preview-html.html
@@ -3,6 +3,6 @@
 
 <!--<div class="col-md-4" style="{{visible}} padding:10px;">-->
 <div>
-    <object class="lazy" width=900 data={{PREVIEW_URL}}{{preview}} height=600>Your browser doesn’t support the object tag.</object>
+    <object class="lazy" data={{PREVIEW_URL}}{{preview}} style="width: 100%; height: auto; min-height: 400px; border:none;">Your browser doesn’t support the object tag.</object>
     <a href="{{PREVIEW_URL}}{{preview}}" title="{{imgname}}" style="word-wrap:break-word; color:blue;" class="pdf_download" target="_blank">Click to expand {{imgname}}</a>
 </div>

--- a/templates/history/templatetags/preview-html.html
+++ b/templates/history/templatetags/preview-html.html
@@ -3,6 +3,6 @@
 
 <!--<div class="col-md-4" style="{{visible}} padding:10px;">-->
 <div>
-    <object class="lazy" data={{PREVIEW_URL}}{{preview}} style="width: 100%; height: auto; min-height: 400px; border:none;">Your browser doesn’t support the object tag.</object>
+    <object class="lazy w-100 h-auto border-0" data={{PREVIEW_URL}}{{preview}} style="min-height: 400px;">Your browser doesn’t support the object tag.</object>
     <a href="{{PREVIEW_URL}}{{preview}}" title="{{imgname}}" style="word-wrap:break-word; color:blue;" class="pdf_download" target="_blank">Click to expand {{imgname}}</a>
 </div>

--- a/templates/history/templatetags/preview-vid.html
+++ b/templates/history/templatetags/preview-vid.html
@@ -3,6 +3,6 @@
 
 <div class="col-md-4" style="{{visible}} padding:10px;">
     <a rel="gallery1" class="thumbnail fancybox" href="{{PREVIEW_URL}}{{preview}}" title="{{imgname}}" style="word-wrap:break-word;">
-        <video width="600" class="lazy" controls loop autoplay><source src="{{PREVIEW_URL}}{{preview}}" type="video/{{file_ext}}">Your browser does not support HTML video.</video>
+        <video class="lazy w-100" style="min-width: 70vw;" controls loop autoplay><source src="{{PREVIEW_URL}}{{preview}}" type="video/{{file_ext}}">Your browser does not support HTML video.</video>
     </a>
 </div>


### PR DESCRIPTION
Previously, the Results section in the history view used a fixed height and width, causing the preview to be non-responsive on mobile devices. This PR removes the fixed dimensions and updates the HTML/CSS to allow for responsive rendering. Testing these changes on a single Freva instance shows that it now scales correctly on smaller screens.
