### PR TITLE
Bug: Remove facet wildcard from solrfield.html tempalate predefiend_facets

### DIFF
--- a/templates/plugins/solrfield.html
+++ b/templates/plugins/solrfield.html
@@ -47,10 +47,7 @@
               url: function (term, page) {
                   term=term.replace('/','');
                   const tmp_data = {
-                      facets : '{{facet}}',
-                      {%if editable %}
-                         {{facet}}: term, // search term
-                      {%endif%}
+                      facets : '{{facet}}'
                   };
                   const tmp_data2 = getActiveFacets('{{facet}}','{{group}}');
                   let res = '/api/freva-nextgen/databrowser/metadata-search/freva/file?';

--- a/templates/plugins/solrfield.html
+++ b/templates/plugins/solrfield.html
@@ -49,7 +49,7 @@
                   const tmp_data = {
                       facets : '{{facet}}',
                       {%if editable %}
-                         {{facet}}: term+'*', // search term
+                         {{facet}}: term, // search term
                       {%endif%}
                   };
                   const tmp_data2 = getActiveFacets('{{facet}}','{{group}}');


### PR DESCRIPTION
When using the `predefined_facet` argument in `Solrfield` for a specific facet that was both restricted and listed in the `predefined_facets`, the query would include both `facet_name=*` and `facet_name=facet_value`. The presence of facet=* would cause the specific value (`facet=blahblah`) to be ignored, breaking the filtering functionality of the `predefined_facet` argument. This PR removes the wildcard character (`*`), allowing facets to be properly restricted and listed according to the values specified in the `predefined_facet` argument.


as an example when we search the `Scenario` here, it has to only show [those params](https://gitlab.dkrz.de/ch1187/plugins4freva/climate-change-profile/-/blob/main/climate-change-profile-wrapper-api.py?ref_type=heads#L117). But as you can see here literally `experiment=rcp26&experiment=rcp85&experiment=rcp45` doesn't effect since we have `experiment=*` in params!

https://www.xces.dkrz.de/plugins/climatechangeprofile/setup/#:~:text=model%20parent%20product.-,Scenario,-rcp85

https://www.xces.dkrz.de/api/databrowser/metadata_search/freva/file?facets=experiment&experiment=*&product=eur-11&variable=pr&variable=tas&project=cordex&project=nukleus&project=cordex-nukleus&experiment=rcp26&experiment=rcp85&experiment=rcp45