### PR TITLE
Fix some minor changes in bbox

### DIFF
--- a/assets/js/Containers/Databrowser/DataBrowserCommand.js
+++ b/assets/js/Containers/Databrowser/DataBrowserCommand.js
@@ -63,7 +63,7 @@ function DataBrowserCommandImpl(props) {
         : "") +
       (props.minDate ? `time=${props.minDate}to${props.maxDate} ` : "") +
       (props.minLon
-        ? `bbox=${props.minLon},${props.maxLon}by${props.minLat},${props.maxLat} `
+        ? `bbox=${props.minLon},${props.maxLon},${props.minLat},${props.maxLat} `
         : "") +
       Object.keys(selectedFacets)
         .map((key) => {
@@ -102,7 +102,7 @@ function DataBrowserCommandImpl(props) {
           <React.Fragment>
             &nbsp;bbox=
             <span className="fw-bold">
-              {`${props.minLon},${props.maxLon}by${props.minLat},${props.maxLat}`}
+              {`${props.minLon},${props.maxLon},${props.minLat},${props.maxLat}`}
             </span>
           </React.Fragment>
         )}
@@ -155,7 +155,7 @@ function DataBrowserCommandImpl(props) {
 
     if (props.minLon) {
       args.push(
-        `bbox="${props.minLon},${props.maxLon} by ${props.minLat},${props.maxLat}"`
+        `bbox="${props.minLon} ${props.maxLon} ${props.minLat} ${props.maxLat}"`
       );
       if (bboxSelectorToCli) {
         args.push(`bbox_select="${bboxSelectorToCli}"`);

--- a/assets/js/Containers/Databrowser/index.js
+++ b/assets/js/Containers/Databrowser/index.js
@@ -98,14 +98,13 @@ class Databrowser extends React.Component {
     }
   }
 
-  createCatalogLink(type, isDynamic = false) {
+  createCatalogLink(type) {
     const baseUrl = `/api/freva-nextgen/databrowser/${type}-catalogue/`;
     const searchParams = prepareSearchParams(
       this.props.location,
       "translate=false"
     );
-    const dynamicParam = isDynamic ? "&stac_dynamic=true" : "";
-    return `${baseUrl}${searchParams}${dynamicParam}`;
+    return `${baseUrl}${searchParams}`;
   }
 
   clickFacet(category, value = null) {

--- a/assets/js/Containers/Databrowser/utils.js
+++ b/assets/js/Containers/Databrowser/utils.js
@@ -35,7 +35,7 @@ export function prepareSearchParams(location, additionalParams = "") {
 
     const isBBoxSelected = !!(minLon && maxLon && minLat && maxLat);
     if (isBBoxSelected) {
-      params += `&bbox_select=${bboxSelector}&bbox=${minLon},${maxLon}by${minLat},${maxLat}`;
+      params += `&bbox_select=${bboxSelector}&bbox=${minLon},${maxLon},${minLat},${maxLat}`;
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evaluation_system_web",
-  "version": "2502.0.0",
+  "version": "2504.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "evaluation_system_web",
-      "version": "2502.0.0",
+      "version": "2504.0.0",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^2.29",


### PR DESCRIPTION
In the most recent version of Freva-nextgen, based on a request change comment, we changed the `bbox` format on API from `minlon,minlonbyminlat,maxlat` to `minlon,minlon,minlat,maxlat`, and we forgot to reflect it on web; now it leads us to invalid format on server side, so via this PR we are going to fix this issue