### PR TITLE
Hotfix: django startup failure

### DIFF
--- a/init_django.sh
+++ b/init_django.sh
@@ -7,6 +7,11 @@ if [ "${DEBUG:-0}" = "1" ]; then
     LOG_LEVEL="debug"
 fi
 
+until python manage.py migrate --check 2>/dev/null; do
+    echo "Waiting for database..."
+    sleep 2
+done
+
 python manage.py makemigrations base
 python manage.py migrate --fake-initial --noinput
 python manage.py migrate --fake contenttypes


### PR DESCRIPTION
Today's morning on startup of one of the Freva instances, the Django app failed to start because the database container wasn’t fully initialized yet, resulting in connection errors. This issue turned out to be a race condition between container startup times. Based on a quick test on a running instance, adding a `migrate --check` step seems to handle the situation properly. @antarcticrainforest even this is a quick hotfix, but given your broader picture of the whole infrastructure, to ensure it doesn’t introduce issues elsewhere, and also since it's an only typical codes Monday morning and we have time until next week failure, I would wait releasing the freva-web until you review it.