### PR TITLE
Hotfix: useMemo to prevernt recalculating rearrangeCodeElements

### DIFF
--- a/assets/js/Containers/FrevaGPT/components/ChatBlock.js
+++ b/assets/js/Containers/FrevaGPT/components/ChatBlock.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import { useSelector } from "react-redux";
 
 import { Col, Card, Modal, Button, Alert } from "react-bootstrap";
@@ -55,6 +55,10 @@ function ChatBlock() {
 
     return newConv;
   }
+
+  const rearrangedConversation = useMemo(() => {
+    return rearrangeCodeElements(conversation);
+  }, [conversation]);
 
   function renderImage(element, index) {
     return (
@@ -154,8 +158,6 @@ function ChatBlock() {
   }
 
   function render() {
-    const rearrangedConversation = rearrangeCodeElements(conversation);
-
     return (
       <>
         <Col>
@@ -186,4 +188,4 @@ function ChatBlock() {
   return render();
 }
 
-export default ChatBlock;
+export default React.memo(ChatBlock);


### PR DESCRIPTION
It's only a surgical fix to don't run rearrangeCodeElements on every render during streaming the backend, and React.memo prevents from re-rendering when only `dynamicAnswer` changes.

Since it worked we opened it here. If you have any proper implementation that works, please close this.

It has been already deployed on playground, and to test it, please prompt something here to get longer response and see the performance:
https://freva-playground.cloud.dkrz.de/chatbot/?thread_id=QuqpRDaHW749VwVKTT7FFNPFVcEH3nhs

or this long conv:
https://freva-playground.cloud.dkrz.de/chatbot/?thread_id=dsjViQo6evYQIzivGPgfVg86lmzpCQVA

ping @antarcticrainforest 