### PR TITLE
Fix: adding timeout to each retry to avoid hanging

### DIFF
--- a/init_django.sh
+++ b/init_django.sh
@@ -14,7 +14,7 @@ wait_for_db() {
 
     for i in $(seq 1 "$MAX_ATTEMPTS"); do
         echo "[$i/$MAX_ATTEMPTS] Checking database readiness..."
-        if python manage.py makemigrations base; then
+        if timeout 10s python manage.py makemigrations base; then
             echo "Database reachable and Django setup succeeded."
             return 0
         fi


### PR DESCRIPTION
Since the `timeout` command is available in the image, this fix should prevent the retry loop from hanging.