### PR TITLE
Fix STAC Browser v5 compatibility with freva-web SPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [v2605.0.0]
+### Fixed
+- Upgraded embedded STAC Browser from v4 (Vue CLI/webpack) to v5 (Vue 3/Vite);
 ## [v2604.3.1]
 ### Fixed
 - Flashing of old code content on rendering new code

--- a/Makefile
+++ b/Makefile
@@ -40,24 +40,24 @@ setup-stacbrowser:
 	rm -rf static_root/stac-browser
 	mkdir -p static_root/stac-browser
 	@if [ ! -d "stac-browser" ]; then \
-		git clone -b v4.0.1 https://github.com/radiantearth/stac-browser.git stac-browser; \
+		git clone https://github.com/radiantearth/stac-browser.git stac-browser; \
 	fi
-	cd stac-browser && \
-	npm install && \
-	npm run build -- --historyMode="hash" --allowExternalAccess=false && \
-	cp -r dist/* ../static_root/stac-browser/
-
-	@APP_JS=$$(ls static_root/stac-browser/js/app.*.js 2>/dev/null | head -1); \
-	if [ -n "$$APP_JS" ]; then \
-		echo "Found app.js: $$APP_JS"; \
-		sed -i 's/catalogUrl:null/catalogUrl:window.STAC_CATALOG_URL/g' "$$APP_JS" 2>/dev/null || sed -i '' 's/catalogUrl:null/catalogUrl:window.STAC_CATALOG_URL/g' "$$APP_JS"; \
-		sed -i 's/showThumbnailsAsAssets:!1/showThumbnailsAsAssets:1/g' "$$APP_JS" 2>/dev/null || sed -i '' 's/showThumbnailsAsAssets:!1/showThumbnailsAsAssets:1/g' "$$APP_JS"; \
-		echo "Modified: $$APP_JS"; \
-	else \
-		echo "Error: app.js not found in static_root/stac-browser/js/"; \
-		ls -la static_root/stac-browser/js/ || echo "Directory does not exist"; \
-		exit 1; \
-	fi
+	cd stac-browser && git checkout -- src/init.js vite.config.js config.js
+	cd stac-browser && patch -p1 --forward < ../stac-browser-patches/stac-browser-init.patch
+	cd stac-browser && patch -p1 --forward < ../stac-browser-patches/stac-browser-vite.patch
+	cd stac-browser && python3 -c "\
+import pathlib; \
+p = pathlib.Path('config.js'); \
+t = p.read_text(); \
+t = t.replace('historyMode: \"history\"', 'historyMode: \"hash\"'); \
+t = t.replace('showThumbnailsAsAssets: false', 'showThumbnailsAsAssets: true'); \
+t = t.replace('pathPrefix: \"/\"', 'pathPrefix: \"/static/stac-browser/\"'); \
+t = t.replace('enforcedColorMode: \"auto\"', 'enforcedColorMode: \"light\"'); \
+p.write_text(t)"
+	cd stac-browser && npm install && npm run build
+	cp -r stac-browser/dist/. static_root/stac-browser/
+	mkdir -p static_root/stac-browser/.vite
+	cp stac-browser/dist/.vite/manifest.json static_root/stac-browser/.vite/manifest.json
 
 runserver:
 	@echo "Starting Django development server..."

--- a/base/views.py
+++ b/base/views.py
@@ -412,9 +412,9 @@ def stacbrowser(request):
     stacapi_url = request.build_absolute_uri(stacapi_endpoint)
 
     try:
-        # based on one usecase, since there are two reverse
-        # proxies in place. To ensure we have the correct URL,
-        # we fetch the STAC API metadata and extract the self link.
+        # Based on one usecase, since there are two reverse proxies in place.
+        # To ensure we have the correct URL, we fetch the STAC API metadata
+        # and extract the self link.
         response = requests.get(stacapi_url, timeout=10)
         response.raise_for_status()
         stac_data = response.json()
@@ -428,20 +428,37 @@ def stacbrowser(request):
     except Exception:
         pass  # Use fallback URL
 
-    # Find the current asset files dynamically
     static_path = os.path.join(settings.PROJECT_ROOT, 'static_root', 'stac-browser')
-    vendor_js = glob.glob(os.path.join(static_path, 'js', 'chunk-vendors.*.js'))
-    app_js = glob.glob(os.path.join(static_path, 'js', 'app.*.js'))
-    vendor_css = glob.glob(os.path.join(static_path, 'css', 'chunk-vendors.*.css'))
-    app_css = glob.glob(os.path.join(static_path, 'css', 'app.*.css'))
+
+    # Vite writes a manifest at .vite/manifest.json when `manifest: true` is
+    # set in vite.config.js.
+    # We look for the entry with `isEntry: true` rather than hardcoding the
+    # key ("src/main.js") so this stays correct across Vite versions.
+    main_js = ''
+    main_css = ''
+    try:
+        manifest_path = os.path.join(static_path, '.vite', 'manifest.json')
+        with open(manifest_path) as fh:
+            manifest = json.load(fh)
+
+        # Find the chunk marked as the entry point
+        entry = next(
+            (v for v in manifest.values() if v.get('isEntry')),
+            {}
+        )
+        main_js = entry.get('file', '')
+        main_css = (entry.get('css') or [''])[0]
+
+    except (FileNotFoundError, json.JSONDecodeError, StopIteration):
+        # stac-browser not built yet; template will log a warning
+        pass
+
     context = {
         'title': 'STAC Browser',
         'stac_api_url': stacapi_url,
         'stac_assets': {
-            'vendor_js': os.path.basename(vendor_js[0]) if vendor_js else '',
-            'app_js': os.path.basename(app_js[0]) if app_js else '',
-            'vendor_css': os.path.basename(vendor_css[0]) if vendor_css else '',
-            'app_css': os.path.basename(app_css[0]) if app_css else '',
+            'main_js': main_js,
+            'main_css': main_css,
         }
     }
     return render(request, 'stacbrowser.html', context)

--- a/stac-browser-patches/stac-browser-init.patch
+++ b/stac-browser-patches/stac-browser-init.patch
@@ -1,0 +1,12 @@
+--- a/src/init.js
++++ b/src/init.js
+@@ -46,7 +46,8 @@ export default function init() {
+     app.use(i18n);
+     app.use(router);
+     app.use(store);
+ 
+-    return app.mount("body");
++    const mountTarget = document.getElementById("stac-browser") ?? "body";
++    return app.mount(mountTarget);
+   });
+ }

--- a/stac-browser-patches/stac-browser-vite.patch
+++ b/stac-browser-patches/stac-browser-vite.patch
@@ -1,0 +1,10 @@
+--- a/vite.config.js
++++ b/vite.config.js
+@@ -81,6 +81,7 @@ export default defineConfig(async ({ mode }) => {
+     build: {
++      manifest: true,
+       sourcemap: mode !== "minimal",
+       rollupOptions: {
+         external: ["fs/promises"],
+       },
+     },

--- a/templates/stacbrowser.html
+++ b/templates/stacbrowser.html
@@ -6,68 +6,66 @@
 {% block title %}STAC Browser{% endblock %}
 
 {% block content %}
-<!-- Pass STAC API and STAC-Browser JS and CSS paths to JavaScript -->
 {{ stac_assets|json_script:"stac-assets" }}
 {{ stac_api_url|json_script:"stac-api-url" }}
 
 <script>
     const assets = JSON.parse(document.getElementById('stac-assets').textContent);
     const stacApiUrl = JSON.parse(document.getElementById('stac-api-url').textContent);
-    
+
+    // v5 merged-config.js reads window.STAC_BROWSER_CONFIG (not window.STAC_CATALOG_URL).
+    // This must be set before the module script loads so it is available when
+    // merged-config.js is evaluated.
+    window.STAC_BROWSER_CONFIG = { catalogUrl: stacApiUrl };
+
     document.addEventListener('DOMContentLoaded', function() {
-        const head = document.head;
-
-        // check for the all required meta tags and create them if they don't exist
-        if (!document.getElementById('og-title')) {
-            const ogTitle = document.createElement('meta');
-            ogTitle.id = 'og-title';
-            ogTitle.property = 'og:title';
-            ogTitle.content = document.title;
-            head.appendChild(ogTitle);
-        }
-
-        if (!document.getElementById('meta-description')) {
-            const metaDesc = document.createElement('meta');
-            metaDesc.id = 'meta-description';
-            metaDesc.name = 'description';
-            metaDesc.content = 'STAC Browser - Evaluation System';
-            head.appendChild(metaDesc);
-        }
-
-        if (!document.getElementById('og-description')) {
-            const ogDesc = document.createElement('meta');
-            ogDesc.id = 'og-description';
-            ogDesc.property = 'og:description';
-            ogDesc.content = 'STAC Browser - Evaluation System';
-            head.appendChild(ogDesc);
-        }
-
-        if (!document.getElementById('og-locale')) {
-            const ogLocale = document.createElement('meta');
-            ogLocale.id = 'og-locale';
-            ogLocale.property = 'og:locale';
-            ogLocale.content = 'en';
-            head.appendChild(ogLocale);
-        }
-
-        if (!document.getElementById('og-url')) {
-            const ogUrl = document.createElement('meta');
-            ogUrl.id = 'og-url';
-            ogUrl.property = 'og:url';
-            ogUrl.content = window.location.href;
-            head.appendChild(ogUrl);
-        }
-        
+        ensureMetaTags();
         loadScopedCSS();
     });
 
+    function ensureMetaTags() {
+        const head = document.head;
+        function ensure(id, attrs) {
+            if (document.getElementById(id)) return;
+            const el = document.createElement('meta');
+            el.id = id;
+            Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+            head.appendChild(el);
+        }
+        ensure('og-title',         { property: 'og:title',       content: document.title });
+        ensure('meta-description', { name:     'description',    content: 'STAC Browser - Evaluation System' });
+        ensure('og-description',   { property: 'og:description', content: 'STAC Browser - Evaluation System' });
+        ensure('og-locale',        { property: 'og:locale',      content: 'en' });
+        ensure('og-url',           { property: 'og:url',         content: window.location.href });
+    }
+
+    // Vite produces one hashed CSS file. Its path (e.g. "assets/index-CXnPQ.css")
+    // is already relative to the stac-browser static root, so we just prepend that.
+    function loadScopedCSS() {
+        return new Promise((resolve) => {
+            if (!assets.main_css) {
+                addDropdownFixes();
+                addLayoutProtection();
+                resolve();
+                return;
+            }
+            const link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.href = `{% static "stac-browser/" %}${assets.main_css}`;
+            link.onload = link.onerror = () => {
+                addDropdownFixes();
+                addLayoutProtection();
+                resolve();
+            };
+            document.head.appendChild(link);
+        });
+    }
+
     function addLayoutProtection() {
-        // Create a style element to protect the main layout
+        if (document.getElementById('stac-layout-protection')) return;
         const protectionStyle = document.createElement('style');
         protectionStyle.id = 'stac-layout-protection';
         protectionStyle.textContent = `
-            /* original max-width number is 1200px, but since it's a SPA
-            we found 1240px by experiment*/
             .container {
                 max-width: 1240px !important;
                 width: 100% !important;
@@ -80,14 +78,12 @@
                 margin: 0 auto !important;
             }
 
-            /* Adjustment of the logo and keep the original behavior */
             header .row.justify-content-between {
-                max-width: 1240px !important; 
-                margin: 0 auto !important; 
+                max-width: 1240px !important;
+                margin: 0 auto !important;
                 justify-content: space-between !important;
             }
 
-            /* Lock column widths to original sizes. 400px is the original size */
             header .col-md-4.col-sm-6 {
                 width: 400px !important;
                 max-width: 400px !important;
@@ -100,7 +96,6 @@
                 flex: 0 0 200px !important;
             }
 
-            /* Lock logo sizes at their original sizes. 376px is the original size */
             header .col-md-4 .logo img {
                 max-width: 376px !important;
                 width: auto !important;
@@ -109,13 +104,11 @@
 
             header .col-md-2 .logo img {
                 max-width: 176px !important;
-                width: auto !important; 
+                width: auto !important;
                 height: auto !important;
             }
 
             @media (max-width: 991px) {
-                /* Aall values below, has been experimentally determined
-                to be the original values for the responsive layout */
                 .navbar-toggler {
                     margin-left: -2px !important;
                 }
@@ -172,57 +165,10 @@
                 max-width: 100% !important;
                 overflow: hidden !important;
             }
-
         `;
         document.head.appendChild(protectionStyle);
     }
 
-    // we load CSS dynamically in script to ensure it is loaded after the DOM is ready
-    // and it prevent conflicts with other styles of freva-web
-    const loadScopedCSS = () => {
-        return new Promise((resolve) => {
-            let loadedCount = 0;
-            const totalFiles = 2;
-            
-            const checkComplete = () => {
-                loadedCount++;
-                if (loadedCount === totalFiles) {
-                    addDropdownFixes();
-                    addLayoutProtection();
-                    resolve();
-                }
-            };
-            
-            // load vendor and app CSS files dynamically
-            const vendorCSS = document.createElement('link');
-            vendorCSS.rel = 'stylesheet';
-            vendorCSS.href = `{% static "stac-browser/css/" %}${assets.vendor_css}`;
-            vendorCSS.onload = () => {
-                checkComplete();
-            };
-            vendorCSS.onerror = () => {
-                checkComplete();
-            };
-            
-            const appCSS = document.createElement('link');
-            appCSS.rel = 'stylesheet';
-            appCSS.href = `{% static "stac-browser/css/" %}${assets.app_css}`;
-            appCSS.onload = () => {
-                checkComplete();
-            };
-            appCSS.onerror = () => {
-                checkComplete();
-            };
-            
-            document.head.appendChild(vendorCSS);
-            document.head.appendChild(appCSS);
-        });
-    };
-    
-    // important:
-    // since the `additional-filters` and `queryable-group` classes are used in the STAC Browser,
-    // we need to ensure that the dropdowns and other elements are properly styled and contained
-    // otherwise they might overflow or not display correctly
     function addDropdownFixes() {
         const style = document.createElement('style');
         style.textContent = `
@@ -395,41 +341,28 @@
     }
 </script>
 
-<!-- Important" Where we import STAC Browser container -->
 <div class="stac-browser-wrapper">
     <div id="stac-browser"></div>
 </div>
 
-<!-- Load STAC Browser config -->
-<script src="{% static 'stac-browser/config.js' %}"></script>
-<script>
-    window.STAC_CATALOG_URL = stacApiUrl;
-</script>
-
-<!-- Load STAC Browser JavaScript -->
 <script>
     window.addEventListener('load', function() {
+        if (!assets.main_js) {
+            console.error(
+                'STAC Browser: main_js is empty. ' +
+                'Make sure `make setup-stacbrowser` ran successfully and ' +
+                '.vite/manifest.json was copied to static_root/stac-browser/.'
+            );
+            return;
+        }
 
-        // Load vendor script and then app script
-        const vendorScript = document.createElement('script');
-        vendorScript.src = `{% static "stac-browser/js/" %}${assets.vendor_js}`;
-        vendorScript.onload = function() {
-
-            const appScript = document.createElement('script');
-            appScript.src = `{% static "stac-browser/js/" %}${assets.app_js}`;
-            appScript.onload = function() {
-                
-                setTimeout(() => {
-                    try {
-                        const vueInstance = document.getElementById('stac-browser').__vue__;
-                    } catch (error) {
-                        console.warn(error);
-                    }
-                }, 1000);
-            };
-            document.head.appendChild(appScript);
-        };
-        document.head.appendChild(vendorScript);
+        // Vite builds are ES modules — script MUST have type="module".
+        // Without it the browser throws SyntaxError on the first import
+        // statement and the app never boots.
+        const script = document.createElement('script');
+        script.type = 'module';
+        script.src = `{% static "stac-browser/" %}${assets.main_js}`;
+        document.head.appendChild(script);
     });
 </script>
 {% endblock %}


### PR DESCRIPTION
Recently STAC-Browser switched from the webpack to vite which broke the whole SPA on web client and we had to froze the version for the time being to keep it working. 
Now this PR upgrades the embedded STAC Browser from v4 to v5, fixing the broken integration caused by the webpack to Vite migration. The new version in a cleaner way mounts to `#stac-browser` instead of hijacking `<body>`, loads assets as ES modules using the Vite manifest, and injects the catalog URL via `window.STAC_BROWSER_CONFIG`. Building the config is patched at setup time to set the correct static file base path, history mode, and light theme.
We disable the STAC-browser dark theme because it was not compatible with the current freva style theme and on the dark mode, it looked a bit Komisch