### PR TITLE
Remove: Remove `/zarr-utils/html` endpoint and render xarray metadata client-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [v2605.1.0]
+### Removed
+- Remove `/zarr-utils/html` endpoint and render xarray metadata client-side
 ## [v2605.0.0]
 ### Removed
 - Guest user concept fully removed from auth, views, forms and templates

--- a/assets/js/Components/NcdumpDialog/detectZarrStore.js
+++ b/assets/js/Components/NcdumpDialog/detectZarrStore.js
@@ -1,0 +1,104 @@
+import { useState, useEffect } from "react";
+
+import { getTokenFromCookie } from "../../utils";
+
+/**
+ * Checks whether a URL already points to a zarr store by probing
+ * .zmetadata (v2 consolidated) and zarr.json (v2/v3).
+ *
+ * we try consolidated metadata first (open_consolidated), then fall back
+ * to bare group detection (open_group).
+ * The `consolidated` flag tells the caller whether client-side metadata
+ * rendering is available; non-consolidated stores are still zarr and can
+ * skip conversion, but won't have a metadata view until server-side rendering.
+ */
+export async function detectZarrStore(url) {
+  if (!url) {
+    return { isZarr: false, version: null, consolidated: false };
+  }
+
+  const base = url.replace(/\/$/, "");
+  const token = getTokenFromCookie();
+  const headers = token
+    ? { Authorization: `${token.token_type} ${token.access_token}` }
+    : {};
+  const opts = {
+    credentials: "same-origin",
+    headers,
+    signal: AbortSignal.timeout(5000),
+  };
+
+  // v2: .zmetadata is consolidated by definition
+  try {
+    const r = await fetch(`${base}/.zmetadata`, opts);
+    if (r.ok) {
+      return { isZarr: true, version: 2, consolidated: true };
+    }
+  } catch {
+    /* I hope linter forgive me */
+  }
+
+  // v2/v3: zarr.json; read zarr_format field to determine version
+  // xarray does the equivalent via zarr_group.metadata.zarr_format after
+  // calling zarr.open_consolidated() or zarr.open_group().
+  try {
+    const r = await fetch(`${base}/zarr.json`, opts);
+    if (r.ok) {
+      const json = await r.json();
+      // 2 or 3 per spec
+      const version = json.zarr_format;
+      if (version === 2 || version === 3) {
+        // consolidated_metadata key present = renderable client-side (v3)
+        const consolidated =
+          // v2 via zarr.json has no .zmetadata
+          version === 3 ? "consolidated_metadata" in json : false;
+        return { isZarr: true, version, consolidated };
+      }
+    }
+  } catch {
+    /* I hope linter forgive me */
+  }
+
+  return { isZarr: false, version: null, consolidated: false };
+}
+
+/**
+ * React hook wrapper around detectZarrStore.
+ * Re-runs whenever `url` changes.
+ */
+export function useZarrDetector(url) {
+  const [state, setState] = useState({
+    isZarr: false,
+    version: null,
+    consolidated: false,
+    checking: !!url,
+  });
+
+  useEffect(() => {
+    if (!url) {
+      setState({
+        isZarr: false,
+        version: null,
+        consolidated: false,
+        checking: false,
+      });
+      return () => {};
+    }
+
+    let cancelled = false;
+    setState((s) => ({ ...s, checking: true }));
+
+    (async () => {
+      const result = await detectZarrStore(url);
+      if (!cancelled) {
+        setState({ ...result, checking: false });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  return state;
+}

--- a/assets/js/Components/NcdumpDialog/useHtmlMetadata.js
+++ b/assets/js/Components/NcdumpDialog/useHtmlMetadata.js
@@ -6,9 +6,17 @@ import { getTokenFromCookie } from "../../utils";
 
 function parseDtypeStr(dtype) {
   const map = {
-    f2: "float16", f4: "float32", f8: "float64",
-    i1: "int8",   i2: "int16",   i4: "int32",  i8: "int64",
-    u1: "uint8",  u2: "uint16",  u4: "uint32", u8: "uint64",
+    f2: "float16",
+    f4: "float32",
+    f8: "float64",
+    i1: "int8",
+    i2: "int16",
+    i4: "int32",
+    i8: "int64",
+    u1: "uint8",
+    u2: "uint16",
+    u4: "uint32",
+    u8: "uint64",
     b1: "bool",
   };
   return map[dtype.slice(1)] ?? dtype;
@@ -46,7 +54,9 @@ function buildDataset(meta, prefix) {
   for (const [, info] of Object.entries(arrays)) {
     const za = info.zarray ?? {};
     const dimNames = (info.zattrs ?? {})._ARRAY_DIMENSIONS ?? [];
-    dimNames.forEach((d, i) => { if (!(d in dims)) dims[d] = za.shape?.[i] ?? 0; });
+    dimNames.forEach((d, i) => {
+      if (!(d in dims)) dims[d] = za.shape?.[i] ?? 0;
+    });
   }
 
   const allVars = {};
@@ -54,26 +64,35 @@ function buildDataset(meta, prefix) {
     const za = info.zarray ?? {};
     const { _ARRAY_DIMENSIONS, ...userAttrs } = info.zattrs ?? {};
     const dimNames = _ARRAY_DIMENSIONS ?? [];
-    const isTime = dimNames.length === 1 && dimNames[0] === name &&
+    const isTime =
+      dimNames.length === 1 &&
+      dimNames[0] === name &&
       (String(userAttrs.units ?? "").includes("since") || name === "time");
     allVars[name] = {
-      shape: za.shape ?? [], chunks: za.chunks ?? za.shape ?? [],
+      shape: za.shape ?? [],
+      chunks: za.chunks ?? za.shape ?? [],
       dtype: parseDtypeStr(za.dtype ?? "|u1"),
-      dims: dimNames, attrs: userAttrs, _isTimeCoord: isTime,
+      dims: dimNames,
+      attrs: userAttrs,
+      _isTimeCoord: isTime,
     };
   }
 
   const coordSet = new Set();
-  const splitWords = s => String(s ?? "").split(/[\s,]+/).filter(Boolean);
+  const splitWords = (s) =>
+    String(s ?? "")
+      .split(/[\s,]+/)
+      .filter(Boolean);
   for (const [name, dv] of Object.entries(allVars)) {
     if (dv.dims.length === 1 && dv.dims[0] === name) coordSet.add(name);
   }
-  splitWords(attrs.coordinates).forEach(c => coordSet.add(c));
+  splitWords(attrs.coordinates).forEach((c) => coordSet.add(c));
   for (const dv of Object.values(allVars)) {
-    splitWords(dv.attrs.coordinates).forEach(c => coordSet.add(c));
+    splitWords(dv.attrs.coordinates).forEach((c) => coordSet.add(c));
   }
 
-  const coords = {}, data_vars = {};
+  const coords = {},
+    data_vars = {};
   for (const [name, dv] of Object.entries(allVars)) {
     (coordSet.has(name) ? coords : data_vars)[name] = dv;
   }
@@ -92,7 +111,9 @@ async function openDatasetMeta(url) {
     const token = getTokenFromCookie();
     const r = await fetch(`${base}/.zmetadata`, {
       credentials: "same-origin",
-      headers: token ? { Authorization: `${token.token_type} ${token.access_token}` } : {},
+      headers: token
+        ? { Authorization: `${token.token_type} ${token.access_token}` }
+        : {},
     });
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     zmeta = await r.json();
@@ -131,33 +152,45 @@ async function openDatasetMeta(url) {
 // xarray HTML renderer
 
 function esc(s) {
-  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 let _uid = 0;
-function uid() { return `xr${++_uid}`; }
+function uid() {
+  return `xr${++_uid}`;
+}
 function icon(id) {
   return `<svg class="icon xr-${id}"><use xlink:href="#${id}"></use></svg>`;
 }
 
 function formatDims(dimSizes, indexedNames) {
   if (!Object.keys(dimSizes).length) return "";
-  const lis = Object.entries(dimSizes).map(([d, n]) =>
-    `<li><span${indexedNames.has(d) ? " class='xr-has-index'" : ""}>${esc(d)}</span>: ${n}</li>`
-  ).join("");
+  const lis = Object.entries(dimSizes)
+    .map(
+      ([d, n]) =>
+        `<li><span${indexedNames.has(d) ? " class='xr-has-index'" : ""}>${esc(d)}</span>: ${n}</li>`
+    )
+    .join("");
   return `<ul class='xr-dim-list'>${lis}</ul>`;
 }
 
 function summarizeAttrs(attrs) {
   const entries = Object.entries(attrs);
   if (!entries.length) return "<em>No attributes</em>";
-  return `<dl class='xr-attrs'>${entries.map(([k, v]) =>
-    `<dt><span>${esc(k)} :</span></dt><dd>${esc(String(v))}</dd>`
-  ).join("")}</dl>`;
+  return `<dl class='xr-attrs'>${entries
+    .map(
+      ([k, v]) => `<dt><span>${esc(k)} :</span></dt><dd>${esc(String(v))}</dd>`
+    )
+    .join("")}</dl>`;
 }
 
 function previewVar(dv) {
   const total = dv.shape.reduce((a, b) => a * b, 1);
-  return total === 0 ? "[]" : `${dv.dtype} (${dv.shape.join(" × ")} = ${total.toLocaleString()})`;
+  return total === 0
+    ? "[]"
+    : `${dv.dtype} (${dv.shape.join(" × ")} = ${total.toLocaleString()})`;
 }
 
 function fmtBytes(n) {
@@ -171,8 +204,9 @@ function buildChunkCube(shape, chunks) {
   if (!shape.length) return "";
   const ndim = Math.min(shape.length, 3);
   const s = shape.slice(-ndim);
-  const vis = n => Math.max(20, Math.min(110, 20 + Math.log10(Math.max(1, n)) * 30));
-  const fmt = n => n.toLocaleString();
+  const vis = (n) =>
+    Math.max(20, Math.min(110, 20 + Math.log10(Math.max(1, n)) * 30));
+  const fmt = (n) => n.toLocaleString();
   const fSize = 11;
   const ts = `font-size:${fSize}px;fill:var(--xr-font-color2);font-family:monospace`;
 
@@ -182,7 +216,7 @@ function buildChunkCube(shape, chunks) {
     const H = ndim === 2 ? vis(s[0]) : 12;
     // room for left label
     const PAD_LEFT = ndim === 2 ? 42 : 2;
-    const PAD_BTM  = 16;
+    const PAD_BTM = 16;
     const svgW = PAD_LEFT + W + 4;
     const svgH = H + PAD_BTM;
     return `<svg width="${Math.ceil(svgW)}" height="${Math.ceil(svgH)}"
@@ -190,43 +224,68 @@ function buildChunkCube(shape, chunks) {
         style="overflow:visible;display:block;flex-shrink:0">
       <rect x="${PAD_LEFT}" y="0" width="${W}" height="${H}"
             style="fill:var(--xr-chunk-face);stroke:var(--xr-chunk-edge);stroke-width:0.8"/>
-      ${ndim === 2 ? `<text x="${PAD_LEFT - 5}" y="${H / 2 + 4}"
-            text-anchor="end" style="${ts}">${fmt(s[0])}</text>` : ""}
+      ${
+        ndim === 2
+          ? `<text x="${PAD_LEFT - 5}" y="${H / 2 + 4}"
+            text-anchor="end" style="${ts}">${fmt(s[0])}</text>`
+          : ""
+      }
       <text x="${PAD_LEFT + W / 2}" y="${H + PAD_BTM - 3}"
             text-anchor="middle" style="${ts}">${fmt(s[ndim - 1])}</text>
     </svg>`;
   }
 
   // 3-D cube
-  const W = vis(s[2]), H = vis(s[1]), D = vis(s[0]);
-  const sk = 0.5, dX = D * sk, dY = D * sk * 0.45;
-  const PAD_TOP = 16, PAD_BTM = 16, PAD_RGT = 52;
+  const W = vis(s[2]),
+    H = vis(s[1]),
+    D = vis(s[0]);
+  const sk = 0.5,
+    dX = D * sk,
+    dY = D * sk * 0.45;
+  const PAD_TOP = 16,
+    PAD_BTM = 16,
+    PAD_RGT = 52;
   const svgW = W + dX + PAD_RGT;
   const svgH = PAD_TOP + H + dY + PAD_BTM;
-  const ox = 2, oy = PAD_TOP + H + dY;
+  const ox = 2,
+    oy = PAD_TOP + H + dY;
   return `<svg width="${Math.ceil(svgW)}" height="${Math.ceil(svgH)}"
       viewBox="0 0 ${Math.ceil(svgW)} ${Math.ceil(svgH)}"
       style="overflow:visible;display:block;flex-shrink:0">
-    <polygon points="${ox},${oy} ${ox+W},${oy} ${ox+W},${oy-H} ${ox},${oy-H}"
+    <polygon points="${ox},${oy} ${ox + W},${oy} ${ox + W},${oy - H} ${ox},${oy - H}"
              style="fill:var(--xr-chunk-face);stroke:var(--xr-chunk-edge);stroke-width:0.8"/>
-    <polygon points="${ox},${oy-H} ${ox+W},${oy-H} ${ox+W+dX},${oy-H-dY} ${ox+dX},${oy-H-dY}"
+    <polygon points="${ox},${oy - H} ${ox + W},${oy - H} ${ox + W + dX},${oy - H - dY} ${ox + dX},${oy - H - dY}"
              style="fill:var(--xr-chunk-top);stroke:var(--xr-chunk-edge);stroke-width:0.8"/>
-    <polygon points="${ox+W},${oy} ${ox+W+dX},${oy-dY} ${ox+W+dX},${oy-H-dY} ${ox+W},${oy-H}"
+    <polygon points="${ox + W},${oy} ${ox + W + dX},${oy - dY} ${ox + W + dX},${oy - H - dY} ${ox + W},${oy - H}"
              style="fill:var(--xr-chunk-side);stroke:var(--xr-chunk-edge);stroke-width:0.8"/>
-    <text x="${ox+W/2}" y="${oy+PAD_BTM-3}"
+    <text x="${ox + W / 2}" y="${oy + PAD_BTM - 3}"
           text-anchor="middle" style="${ts}">${fmt(s[2])}</text>
-    <text x="${ox+W/2+dX/2}" y="${PAD_TOP-3}"
+    <text x="${ox + W / 2 + dX / 2}" y="${PAD_TOP - 3}"
           text-anchor="middle" style="${ts}">${fmt(s[1])}</text>
-    <text x="${ox+W+dX+5}" y="${oy-H/2-dY/2+4}"
+    <text x="${ox + W + dX + 5}" y="${oy - H / 2 - dY / 2 + 4}"
           text-anchor="start" style="${ts}">${fmt(s[0])}</text>
   </svg>`;
 }
 
 function buildDataRepr(dv) {
   const { shape, chunks, dtype } = dv;
-  const elemBytes = { int8:1,uint8:1,bool:1,int16:2,uint16:2,int32:4,uint32:4,float32:4,int64:8,uint64:8,float64:8 }[dtype] ?? 4;
+  const elemBytes =
+    {
+      int8: 1,
+      uint8: 1,
+      bool: 1,
+      int16: 2,
+      uint16: 2,
+      int32: 4,
+      uint32: 4,
+      float32: 4,
+      int64: 8,
+      uint64: 8,
+      float64: 8,
+    }[dtype] ?? 4;
   const arrayBytes = shape.reduce((a, b) => a * b, 1) * elemBytes;
-  let chunkBytes = null, nChunks = null;
+  let chunkBytes = null,
+    nChunks = null;
   if (chunks && chunks.length === shape.length) {
     chunkBytes = chunks.reduce((a, b) => a * b, 1) * elemBytes;
     nChunks = shape.reduce((tot, s, i) => tot * Math.ceil(s / chunks[i]), 1);
@@ -245,10 +304,10 @@ function buildDataRepr(dv) {
           <th style="font-weight:600;padding:0 0 5px 0;text-align:left">Chunk</th>
         </tr></thead><tbody>
           ${row("Bytes", fmtBytes(arrayBytes), chunkBytes !== null ? fmtBytes(chunkBytes) : "—")}
-          ${row("Shape", "("+shape.join(", ")+")", chunks ? "("+chunks.join(", ")+")" : "—")}
-          ${nChunks !== null ? row("Chunks", nChunks.toLocaleString()+" chunks") : ""}
+          ${row("Shape", "(" + shape.join(", ") + ")", chunks ? "(" + chunks.join(", ") + ")" : "—")}
+          ${nChunks !== null ? row("Chunks", nChunks.toLocaleString() + " chunks") : ""}
           ${row("dtype", esc(dtype))}
-          ${row("dims", "("+dv.dims.join(", ")+")")}
+          ${row("dims", "(" + dv.dims.join(", ") + ")")}
         </tbody>
       </table>
     </td>
@@ -257,7 +316,8 @@ function buildDataRepr(dv) {
 }
 
 function summarizeVariable(name, dv, isIndex) {
-  const aId = uid(), dId = uid();
+  const aId = uid(),
+    dId = uid();
   const hasAttrs = Object.keys(dv.attrs).length > 0;
   return `
     <div class='xr-var-name'><span${isIndex ? " class='xr-has-index'" : ""}>${esc(name)}</span></div>
@@ -274,14 +334,22 @@ function summarizeVariable(name, dv, isIndex) {
 }
 
 function varListHtml(vars, indexedNames) {
-  return `<ul class='xr-var-list'>${
-    Object.entries(vars).map(([name, dv]) =>
-      `<li class='xr-var-item'>${summarizeVariable(name, dv, indexedNames.has(name))}</li>`
-    ).join("")
-  }</ul>`;
+  return `<ul class='xr-var-list'>${Object.entries(vars)
+    .map(
+      ([name, dv]) =>
+        `<li class='xr-var-item'>${summarizeVariable(name, dv, indexedNames.has(name))}</li>`
+    )
+    .join("")}</ul>`;
 }
 
-function collapsibleSection(header, inline, details, nItems, enabled, collapsed) {
+function collapsibleSection(
+  header,
+  inline,
+  details,
+  nItems,
+  enabled,
+  collapsed
+) {
   const id = uid();
   const hasItems = nItems > 0;
   const nSpan = nItems !== null ? ` <span>(${nItems})</span>` : "";
@@ -311,15 +379,53 @@ const XR_ICONS = `<svg style="position:absolute;width:0;height:0;overflow:hidden
 function renderDataset(ds) {
   const coordNames = new Set(Object.keys(ds.coords));
   const sections = [];
-  sections.push(collapsibleSection("Dimensions:", formatDims(ds.dims, coordNames), "", Object.keys(ds.dims).length, false, true));
+  sections.push(
+    collapsibleSection(
+      "Dimensions:",
+      formatDims(ds.dims, coordNames),
+      "",
+      Object.keys(ds.dims).length,
+      false,
+      true
+    )
+  );
   if (Object.keys(ds.coords).length) {
-    sections.push(collapsibleSection("Coordinates:", "", varListHtml(ds.coords, coordNames), Object.keys(ds.coords).length, true, false));
+    sections.push(
+      collapsibleSection(
+        "Coordinates:",
+        "",
+        varListHtml(ds.coords, coordNames),
+        Object.keys(ds.coords).length,
+        true,
+        false
+      )
+    );
   }
-  sections.push(collapsibleSection("Data variables:", "", varListHtml(ds.data_vars, new Set()), Object.keys(ds.data_vars).length, true, false));
+  sections.push(
+    collapsibleSection(
+      "Data variables:",
+      "",
+      varListHtml(ds.data_vars, new Set()),
+      Object.keys(ds.data_vars).length,
+      true,
+      false
+    )
+  );
   if (Object.keys(ds.attrs).length) {
-    sections.push(collapsibleSection("Attributes:", "", summarizeAttrs(ds.attrs), Object.keys(ds.attrs).length, true, true));
+    sections.push(
+      collapsibleSection(
+        "Attributes:",
+        "",
+        summarizeAttrs(ds.attrs),
+        Object.keys(ds.attrs).length,
+        true,
+        true
+      )
+    );
   }
-  const sectHtml = sections.map(s => `<li class='xr-section-item'>${s}</li>`).join("");
+  const sectHtml = sections
+    .map((s) => `<li class='xr-section-item'>${s}</li>`)
+    .join("");
   return `<div class='xr-root'>
     <div class='xr-wrap'>
       <div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div>
@@ -335,7 +441,9 @@ function buildXarrayRepr(result) {
   }
 
   // Multi-group store
-  const cards = Object.entries(result.groups).map(([name, ds]) => `
+  const cards = Object.entries(result.groups)
+    .map(
+      ([name, ds]) => `
     <details open style="margin-bottom:10px;border:1px solid var(--xr-border-color);border-radius:4px;overflow:hidden">
       <summary style="padding:8px 12px;font-weight:600;cursor:pointer;background:var(--xr-background-color-row-odd);list-style:none;display:flex;align-items:center;gap:8px">
         <span style="font-size:11px;color:var(--xr-font-color2)">▶</span>
@@ -343,7 +451,9 @@ function buildXarrayRepr(result) {
       </summary>
       <div style="padding:0 12px 8px">${renderDataset(ds)}</div>
     </details>
-  `).join("");
+  `
+    )
+    .join("");
 
   return `${XR_ICONS}<div style="font-family:monospace">${cards}</div>`;
 }
@@ -432,13 +542,15 @@ function injectXarrayCss() {
   const r = parseInt(hex.slice(0, 2), 16);
   const g = parseInt(hex.slice(2, 4), 16);
   const b = parseInt(hex.slice(4, 6), 16);
-  const cl = f => `rgb(${Math.min(255,r*f|0)},${Math.min(255,g*f|0)},${Math.min(255,b*f|0)})`;
-  const ca = (f, a) => `rgba(${Math.min(255,r*f|0)},${Math.min(255,g*f|0)},${Math.min(255,b*f|0)},${a})`;
+  const cl = (f) =>
+    `rgb(${Math.min(255, (r * f) | 0)},${Math.min(255, (g * f) | 0)},${Math.min(255, (b * f) | 0)})`;
+  const ca = (f, a) =>
+    `rgba(${Math.min(255, (r * f) | 0)},${Math.min(255, (g * f) | 0)},${Math.min(255, (b * f) | 0)},${a})`;
 
   const chunkVars = `
     :root{--xr-chunk-face:${cl(0.85)};--xr-chunk-top:${cl(1.25)};--xr-chunk-side:${cl(0.55)};--xr-chunk-edge:${cl(0.25)}}
     html[data-theme="dark"],body[data-theme="dark"],body.vscode-dark{
-      --xr-chunk-face:${ca(0.85,.65)};--xr-chunk-top:${ca(1.25,.65)};--xr-chunk-side:${ca(0.55,.65)};--xr-chunk-edge:${ca(0.25,.4)}
+      --xr-chunk-face:${ca(0.85, 0.65)};--xr-chunk-top:${ca(1.25, 0.65)};--xr-chunk-side:${ca(0.55, 0.65)};--xr-chunk-edge:${ca(0.25, 0.4)}
     }
   `;
 
@@ -451,10 +563,7 @@ function injectXarrayCss() {
 // Hook to fetch .zmetadata and build an HTML representation
 // of the dataset using xarray's style.
 // it fires only after the zarr conversion job is done
-export function useHtmlMetadata(
-  rawZarrUrl,
-  { enabled = false } = {}
-) {
+export function useHtmlMetadata(rawZarrUrl, { enabled = false } = {}) {
   const [html, setHtml] = useState(null);
   const [error, setError] = useState(null);
 
@@ -477,7 +586,9 @@ export function useHtmlMetadata(
       }
     })();
 
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [rawZarrUrl, enabled]);
 
   return { html, error };

--- a/assets/js/Components/NcdumpDialog/useHtmlMetadata.js
+++ b/assets/js/Components/NcdumpDialog/useHtmlMetadata.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 
 import { getTokenFromCookie } from "../../utils";
 
-// Zarr metadata reader
+// Zarr metadata parsers
 
 function parseDtypeStr(dtype) {
   const map = {
@@ -26,12 +26,11 @@ function parseDtypeStr(dtype) {
  * Given the flat .zmetadata map and a key prefix (e.g. "group0/" or ""),
  * we build a single { dims, coords, data_vars, attrs } dataset object.
  */
-function buildDataset(meta, prefix) {
+// V2: reads from .zmetadata flat key map
+function buildDatasetV2(meta, prefix) {
   const attrs = meta[`${prefix}.zattrs`] ?? {};
-  // Important: We collect arrays that are direct children of this prefix only.
-  // e.g. for prefix "group0/", "group0/var/.zarray" is included but
-  // "group0/sub/var/.zarray" (nested group) is skipped.
   const arrays = {};
+
   for (const [key, val] of Object.entries(meta)) {
     if (!key.startsWith(prefix)) {
       continue;
@@ -54,30 +53,144 @@ function buildDataset(meta, prefix) {
     }
   }
 
-  const dims = {};
-  for (const [, info] of Object.entries(arrays)) {
-    const za = info.zarray ?? {};
-    const dimNames = (info.zattrs ?? {})._ARRAY_DIMENSIONS ?? [];
-    dimNames.forEach((d, i) => {
-      if (!(d in dims)) {
-        dims[d] = za.shape?.[i] ?? 0;
+  return assembleDataset(arrays, attrs, (info) => ({
+    shape: info.zarray?.shape ?? [],
+    chunks: info.zarray?.chunks ?? info.zarray?.shape ?? [],
+    dtype: parseDtypeStr(info.zarray?.dtype ?? "|u1"),
+    dims: info.zattrs?._ARRAY_DIMENSIONS ?? [],
+    attrs: (({ _ARRAY_DIMENSIONS, ...rest }) => rest)(info.zattrs ?? {}),
+  }));
+}
+
+function parseV2(json) {
+  const meta = json.metadata ?? {};
+
+  const groupNames = new Set();
+  for (const key of Object.keys(meta)) {
+    if (key === ".zgroup" || key === ".zattrs") {
+      continue;
+    }
+    if (key.endsWith("/.zgroup")) {
+      const name = key.slice(0, -8);
+      if (!name.includes("/")) {
+        groupNames.add(name);
       }
-    });
+    }
   }
 
+  if (groupNames.size === 0) {
+    const ds = buildDatasetV2(meta, "");
+    if (!Object.keys({ ...ds.coords, ...ds.data_vars }).length) {
+      throw new Error("No arrays found in .zmetadata");
+    }
+    return { groups: null, ...ds };
+  }
+
+  const groups = {};
+  for (const name of [...groupNames].sort()) {
+    groups[name] = buildDatasetV2(meta, `${name}/`);
+  }
+  return { groups };
+}
+
+// V3: reads from zarr.json consolidated_metadata
+
+function buildDatasetV3(meta, prefix) {
+  const rootKey = prefix || "";
+  const attrs = (meta[rootKey] ?? {}).attributes ?? {};
+  const arrays = {};
+
+  for (const [key, val] of Object.entries(meta)) {
+    if (val.node_type !== "array") {
+      continue;
+    }
+    if (prefix) {
+      if (!key.startsWith(`${prefix}/`)) {
+        continue;
+      }
+      const rel = key.slice(prefix.length + 1);
+      if (rel.includes("/")) {
+        continue;
+      }
+      arrays[rel] = { zarray: val };
+    } else {
+      if (!key || key.includes("/")) {
+        continue;
+      }
+      arrays[key] = { zarray: val };
+    }
+  }
+
+  return assembleDataset(arrays, attrs, (info) => {
+    const v = info.zarray;
+    return {
+      shape: v.shape ?? [],
+      chunks: v.chunk_grid?.configuration?.chunk_shape ?? v.shape ?? [],
+      // v3 is human-readable
+      dtype: v.data_type ?? "float32",
+      dims: v.dimension_names ?? [],
+      attrs: v.attributes ?? {},
+    };
+  });
+}
+
+function parseV3(json) {
+  const meta = json.consolidated_metadata?.metadata ?? {};
+  if (!Object.keys(meta).length) {
+    throw new Error("zarr.json has no consolidated_metadata");
+  }
+
+  const groupNames = new Set();
+  for (const [key, val] of Object.entries(meta)) {
+    if (!key || val.node_type !== "group") {
+      continue;
+    }
+    if (!key.includes("/")) {
+      groupNames.add(key);
+    }
+  }
+
+  if (groupNames.size === 0) {
+    const ds = buildDatasetV3(meta, "");
+    if (!Object.keys({ ...ds.coords, ...ds.data_vars }).length) {
+      throw new Error("No arrays found in zarr.json");
+    }
+    return { groups: null, ...ds };
+  }
+
+  const groups = {};
+  for (const name of [...groupNames].sort()) {
+    groups[name] = buildDatasetV3(meta, name);
+  }
+  return { groups };
+}
+
+// shared assembly (V2 + V3)
+function assembleDataset(arrays, attrs, extract) {
+  const dims = {};
   const allVars = {};
+
   for (const [name, info] of Object.entries(arrays)) {
-    const za = info.zarray ?? {};
-    const { _ARRAY_DIMENSIONS, ...userAttrs } = info.zattrs ?? {};
-    const dimNames = _ARRAY_DIMENSIONS ?? [];
+    const {
+      shape,
+      chunks,
+      dtype,
+      dims: dimNames,
+      attrs: userAttrs,
+    } = extract(info);
+    dimNames.forEach((d, i) => {
+      if (!(d in dims)) {
+        dims[d] = shape[i] ?? 0;
+      }
+    });
     const isTime =
       dimNames.length === 1 &&
       dimNames[0] === name &&
       (String(userAttrs.units ?? "").includes("since") || name === "time");
     allVars[name] = {
-      shape: za.shape ?? [],
-      chunks: za.chunks ?? za.shape ?? [],
-      dtype: parseDtypeStr(za.dtype ?? "|u1"),
+      shape,
+      chunks,
+      dtype,
       dims: dimNames,
       attrs: userAttrs,
       _isTimeCoord: isTime,
@@ -107,63 +220,54 @@ function buildDataset(meta, prefix) {
   return { dims, coords, data_vars, attrs };
 }
 
+// ── entry point ───────────────────────────────────────────────────────────────
 /**
- * Fetches .zmetadata and returns either:
+ * Fetches (v2:zmetadata.sjon and v3:zarr.json) and returns either:
  *   { groups: null, ...dataset }; flat store
  *   { groups: { name -> dataset } }; multi-group store
  */
 async function openDatasetMeta(url) {
   const base = url.replace(/\/$/, "");
-  let zmeta;
+  const token = getTokenFromCookie();
+  const headers = token
+    ? { Authorization: `${token.token_type} ${token.access_token}` }
+    : {};
+  const opts = { credentials: "same-origin", headers };
+
+  // Try v2 first, then v3
+  let json = null,
+    version = 0;
+
   try {
-    const token = getTokenFromCookie();
-    const r = await fetch(`${base}/.zmetadata`, {
-      credentials: "same-origin",
-      headers: token
-        ? { Authorization: `${token.token_type} ${token.access_token}` }
-        : {},
-    });
-    if (!r.ok) {
-      throw new Error(`HTTP ${r.status}`);
+    const r = await fetch(`${base}/.zmetadata`, opts);
+    if (r.ok) {
+      json = await r.json();
+      version = 2;
     }
-    zmeta = await r.json();
-  } catch (e) {
-    throw new Error(`Could not read .zmetadata: ${e.message}`);
+  } catch {
+    /* I hope linter forgive me */
   }
 
-  const meta = zmeta.metadata ?? {};
-  // Detect top-level groups: keys like "group0/.zgroup"
-  const groupNames = new Set();
-  for (const key of Object.keys(meta)) {
-    if (key === ".zgroup" || key === ".zattrs") {
-      continue;
-    }
-    if (key.endsWith("/.zgroup")) {
-      const name = key.slice(0, -8);
-      if (!name.includes("/")) {
-        groupNames.add(name);
+  if (!json) {
+    try {
+      const r = await fetch(`${base}/zarr.json`, opts);
+      if (r.ok) {
+        json = await r.json();
+        version = 3;
       }
+    } catch {
+      /* I hope linter forgive me */
     }
   }
 
-  if (groupNames.size === 0) {
-    const ds = buildDataset(meta, "");
-    if (!Object.keys({ ...ds.coords, ...ds.data_vars }).length) {
-      throw new Error("No arrays found in .zmetadata");
-    }
-    return { groups: null, ...ds };
+  if (!json) {
+    throw new Error("Could not read zarr metadata (.zmetadata or zarr.json)");
   }
 
-  // Multi-group: build one dataset per group, sorted alphabetically
-  const groups = {};
-  for (const name of [...groupNames].sort()) {
-    groups[name] = buildDataset(meta, `${name}/`);
-  }
-  return { groups };
+  return version === 2 ? parseV2(json) : parseV3(json);
 }
 
 // xarray HTML renderer
-
 function esc(s) {
   return String(s)
     .replace(/&/g, "&amp;")
@@ -236,10 +340,8 @@ function buildChunkCube(shape) {
   const ts = `font-size:${fSize}px;fill:var(--xr-font-color2);font-family:monospace`;
 
   if (ndim < 3) {
-    // Flat rectangle for 1-D and 2-D
     const W = vis(s[ndim - 1]);
     const H = ndim === 2 ? vis(s[0]) : 12;
-    // room for left label
     const PAD_LEFT = ndim === 2 ? 42 : 2;
     const PAD_BTM = 16;
     const svgW = PAD_LEFT + W + 4;
@@ -260,7 +362,6 @@ function buildChunkCube(shape) {
     </svg>`;
   }
 
-  // 3-D cube
   const W = vis(s[2]),
     H = vis(s[1]),
     D = vis(s[0]);
@@ -389,7 +490,6 @@ function collapsibleSection(
   `;
 }
 
-// Xarray SVG icon sprites
 const XR_ICONS = `<svg style="position:absolute;width:0;height:0;overflow:hidden"><defs>
 <symbol id="icon-database" viewBox="0 0 32 32">
   <path d="M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z"/>
@@ -463,7 +563,6 @@ function buildXarrayRepr(result) {
   if (!result.groups) {
     return `${XR_ICONS}${renderDataset(result)}`;
   }
-  // Multi-group store
   const cards = Object.entries(result.groups)
     .map(
       ([name, ds]) => `
@@ -584,9 +683,10 @@ function injectXarrayCss() {
   document.head.appendChild(style);
 }
 
-// Hook to fetch .zmetadata and build an HTML representation
+// Hook to fetch (v2: .zmetadata, v3: zarr.json) and build an HTML representation
 // of the dataset using xarray's style.
 // it fires only after the zarr conversion job is done
+
 export function useHtmlMetadata(rawZarrUrl, { enabled = false } = {}) {
   const [html, setHtml] = useState(null);
   const [error, setError] = useState(null);

--- a/assets/js/Components/NcdumpDialog/useHtmlMetadata.js
+++ b/assets/js/Components/NcdumpDialog/useHtmlMetadata.js
@@ -28,23 +28,27 @@ function parseDtypeStr(dtype) {
  */
 function buildDataset(meta, prefix) {
   const attrs = meta[`${prefix}.zattrs`] ?? {};
-
   // Important: We collect arrays that are direct children of this prefix only.
   // e.g. for prefix "group0/", "group0/var/.zarray" is included but
   // "group0/sub/var/.zarray" (nested group) is skipped.
   const arrays = {};
   for (const [key, val] of Object.entries(meta)) {
-    if (!key.startsWith(prefix)) continue;
+    if (!key.startsWith(prefix)) {
+      continue;
+    }
     const rel = key.slice(prefix.length);
     if (rel.endsWith("/.zarray")) {
       const name = rel.slice(0, -8);
-      // nested group — skip
-      if (name.includes("/")) continue;
+      if (name.includes("/")) {
+        continue;
+      }
       arrays[name] ??= {};
       arrays[name].zarray = val;
     } else if (rel.endsWith("/.zattrs")) {
       const name = rel.slice(0, -8);
-      if (!name || name.includes("/")) continue;
+      if (!name || name.includes("/")) {
+        continue;
+      }
       arrays[name] ??= {};
       arrays[name].zattrs = val;
     }
@@ -55,7 +59,9 @@ function buildDataset(meta, prefix) {
     const za = info.zarray ?? {};
     const dimNames = (info.zattrs ?? {})._ARRAY_DIMENSIONS ?? [];
     dimNames.forEach((d, i) => {
-      if (!(d in dims)) dims[d] = za.shape?.[i] ?? 0;
+      if (!(d in dims)) {
+        dims[d] = za.shape?.[i] ?? 0;
+      }
     });
   }
 
@@ -84,7 +90,9 @@ function buildDataset(meta, prefix) {
       .split(/[\s,]+/)
       .filter(Boolean);
   for (const [name, dv] of Object.entries(allVars)) {
-    if (dv.dims.length === 1 && dv.dims[0] === name) coordSet.add(name);
+    if (dv.dims.length === 1 && dv.dims[0] === name) {
+      coordSet.add(name);
+    }
   }
   splitWords(attrs.coordinates).forEach((c) => coordSet.add(c));
   for (const dv of Object.values(allVars)) {
@@ -102,7 +110,7 @@ function buildDataset(meta, prefix) {
 /**
  * Fetches .zmetadata and returns either:
  *   { groups: null, ...dataset }; flat store
- *   { groups: { name → dataset } }; multi-group store
+ *   { groups: { name -> dataset } }; multi-group store
  */
 async function openDatasetMeta(url) {
   const base = url.replace(/\/$/, "");
@@ -115,21 +123,26 @@ async function openDatasetMeta(url) {
         ? { Authorization: `${token.token_type} ${token.access_token}` }
         : {},
     });
-    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    if (!r.ok) {
+      throw new Error(`HTTP ${r.status}`);
+    }
     zmeta = await r.json();
   } catch (e) {
     throw new Error(`Could not read .zmetadata: ${e.message}`);
   }
 
   const meta = zmeta.metadata ?? {};
-
   // Detect top-level groups: keys like "group0/.zgroup"
   const groupNames = new Set();
   for (const key of Object.keys(meta)) {
-    if (key === ".zgroup" || key === ".zattrs") continue;
+    if (key === ".zgroup" || key === ".zattrs") {
+      continue;
+    }
     if (key.endsWith("/.zgroup")) {
       const name = key.slice(0, -8);
-      if (!name.includes("/")) groupNames.add(name);
+      if (!name.includes("/")) {
+        groupNames.add(name);
+      }
     }
   }
 
@@ -166,7 +179,9 @@ function icon(id) {
 }
 
 function formatDims(dimSizes, indexedNames) {
-  if (!Object.keys(dimSizes).length) return "";
+  if (!Object.keys(dimSizes).length) {
+    return "";
+  }
   const lis = Object.entries(dimSizes)
     .map(
       ([d, n]) =>
@@ -178,7 +193,9 @@ function formatDims(dimSizes, indexedNames) {
 
 function summarizeAttrs(attrs) {
   const entries = Object.entries(attrs);
-  if (!entries.length) return "<em>No attributes</em>";
+  if (!entries.length) {
+    return "<em>No attributes</em>";
+  }
   return `<dl class='xr-attrs'>${entries
     .map(
       ([k, v]) => `<dt><span>${esc(k)} :</span></dt><dd>${esc(String(v))}</dd>`
@@ -190,18 +207,26 @@ function previewVar(dv) {
   const total = dv.shape.reduce((a, b) => a * b, 1);
   return total === 0
     ? "[]"
-    : `${dv.dtype} (${dv.shape.join(" × ")} = ${total.toLocaleString()})`;
+    : `${dv.dtype} (${dv.shape.join(" \u00d7 ")} = ${total.toLocaleString()})`;
 }
 
 function fmtBytes(n) {
-  if (n < 1024) return n + " B";
-  if (n < 1024 ** 2) return (n / 1024).toFixed(2) + " KiB";
-  if (n < 1024 ** 3) return (n / 1024 ** 2).toFixed(2) + " MiB";
+  if (n < 1024) {
+    return n + " B";
+  }
+  if (n < 1024 ** 2) {
+    return (n / 1024).toFixed(2) + " KiB";
+  }
+  if (n < 1024 ** 3) {
+    return (n / 1024 ** 2).toFixed(2) + " MiB";
+  }
   return (n / 1024 ** 3).toFixed(2) + " GiB";
 }
 
-function buildChunkCube(shape, chunks) {
-  if (!shape.length) return "";
+function buildChunkCube(shape) {
+  if (!shape.length) {
+    return "";
+  }
   const ndim = Math.min(shape.length, 3);
   const s = shape.slice(-ndim);
   const vis = (n) =>
@@ -303,15 +328,15 @@ function buildDataRepr(dv) {
           <th style="font-weight:600;padding:0 16px 5px 0;text-align:left">Array</th>
           <th style="font-weight:600;padding:0 0 5px 0;text-align:left">Chunk</th>
         </tr></thead><tbody>
-          ${row("Bytes", fmtBytes(arrayBytes), chunkBytes !== null ? fmtBytes(chunkBytes) : "—")}
-          ${row("Shape", "(" + shape.join(", ") + ")", chunks ? "(" + chunks.join(", ") + ")" : "—")}
+          ${row("Bytes", fmtBytes(arrayBytes), chunkBytes !== null ? fmtBytes(chunkBytes) : "\u2014")}
+          ${row("Shape", "(" + shape.join(", ") + ")", chunks ? "(" + chunks.join(", ") + ")" : "\u2014")}
           ${nChunks !== null ? row("Chunks", nChunks.toLocaleString() + " chunks") : ""}
           ${row("dtype", esc(dtype))}
           ${row("dims", "(" + dv.dims.join(", ") + ")")}
         </tbody>
       </table>
     </td>
-    <td style="vertical-align:middle;padding:0 0 0 32px">${buildChunkCube(shape, chunks ?? shape)}</td>
+    <td style="vertical-align:middle;padding:0 0 0 32px">${buildChunkCube(shape)}</td>
   </tr></table>`;
 }
 
@@ -435,18 +460,16 @@ function renderDataset(ds) {
 }
 
 function buildXarrayRepr(result) {
-  // Flat store
   if (!result.groups) {
     return `${XR_ICONS}${renderDataset(result)}`;
   }
-
   // Multi-group store
   const cards = Object.entries(result.groups)
     .map(
       ([name, ds]) => `
     <details open style="margin-bottom:10px;border:1px solid var(--xr-border-color);border-radius:4px;overflow:hidden">
       <summary style="padding:8px 12px;font-weight:600;cursor:pointer;background:var(--xr-background-color-row-odd);list-style:none;display:flex;align-items:center;gap:8px">
-        <span style="font-size:11px;color:var(--xr-font-color2)">▶</span>
+        <span style="font-size:11px;color:var(--xr-font-color2)">\u25b6</span>
         <span>Group: ${esc(name)}</span>
       </summary>
       <div style="padding:0 12px 8px">${renderDataset(ds)}</div>
@@ -454,7 +477,6 @@ function buildXarrayRepr(result) {
   `
     )
     .join("");
-
   return `${XR_ICONS}<div style="font-family:monospace">${cards}</div>`;
 }
 
@@ -535,7 +557,9 @@ dl.xr-attrs{padding:0;margin:0;display:grid;grid-template-columns:125px auto}
 
 let cssInjected = false;
 function injectXarrayCss() {
-  if (cssInjected) return;
+  if (cssInjected) {
+    return;
+  }
   cssInjected = true;
 
   const hex = (window.MAIN_COLOR || "#9b7a52").replace(/^#/, "");
@@ -571,7 +595,9 @@ export function useHtmlMetadata(rawZarrUrl, { enabled = false } = {}) {
     setHtml(null);
     setError(null);
 
-    if (!rawZarrUrl || !enabled) return () => {};
+    if (!rawZarrUrl || !enabled) {
+      return () => {};
+    }
 
     injectXarrayCss();
 
@@ -580,9 +606,13 @@ export function useHtmlMetadata(rawZarrUrl, { enabled = false } = {}) {
     (async () => {
       try {
         const ds = await openDatasetMeta(rawZarrUrl);
-        if (!cancelled) setHtml(buildXarrayRepr(ds));
+        if (!cancelled) {
+          setHtml(buildXarrayRepr(ds));
+        }
       } catch (e) {
-        if (!cancelled) setError(e.message);
+        if (!cancelled) {
+          setError(e.message);
+        }
       }
     })();
 

--- a/assets/js/Components/NcdumpDialog/useHtmlMetadata.js
+++ b/assets/js/Components/NcdumpDialog/useHtmlMetadata.js
@@ -1,75 +1,459 @@
 import { useState, useEffect } from "react";
 
-import { TEMP_FREVA_AUTH_TOKEN } from "../../Containers/Databrowser/constants";
+import { getTokenFromCookie } from "../../utils";
+
+// Zarr metadata reader
+
+function parseDtypeStr(dtype) {
+  const map = {
+    f2: "float16", f4: "float32", f8: "float64",
+    i1: "int8",   i2: "int16",   i4: "int32",  i8: "int64",
+    u1: "uint8",  u2: "uint16",  u4: "uint32", u8: "uint64",
+    b1: "bool",
+  };
+  return map[dtype.slice(1)] ?? dtype;
+}
 
 /**
- * Returns the Authorization header for the current user, or an empty object
- * when no token is present
+ * Given the flat .zmetadata map and a key prefix (e.g. "group0/" or ""),
+ * we build a single { dims, coords, data_vars, attrs } dataset object.
  */
-function getAuthHeaders() {
-  const cookies = document.cookie.split(";");
-  const authCookie = cookies.find((c) =>
-    c.trim().startsWith(TEMP_FREVA_AUTH_TOKEN)
-  );
+function buildDataset(meta, prefix) {
+  const attrs = meta[`${prefix}.zattrs`] ?? {};
 
-  if (!authCookie) {
-    return {};
-  }
-
-  try {
-    let value = authCookie.substring(authCookie.indexOf("=") + 1).trim();
-    if (value.startsWith('"') && value.endsWith('"')) {
-      value = value.slice(1, -1);
+  // Important: We collect arrays that are direct children of this prefix only.
+  // e.g. for prefix "group0/", "group0/var/.zarray" is included but
+  // "group0/sub/var/.zarray" (nested group) is skipped.
+  const arrays = {};
+  for (const [key, val] of Object.entries(meta)) {
+    if (!key.startsWith(prefix)) continue;
+    const rel = key.slice(prefix.length);
+    if (rel.endsWith("/.zarray")) {
+      const name = rel.slice(0, -8);
+      // nested group — skip
+      if (name.includes("/")) continue;
+      arrays[name] ??= {};
+      arrays[name].zarray = val;
+    } else if (rel.endsWith("/.zattrs")) {
+      const name = rel.slice(0, -8);
+      if (!name || name.includes("/")) continue;
+      arrays[name] ??= {};
+      arrays[name].zattrs = val;
     }
-    return value ? { Authorization: `Bearer ${value}` } : {};
-  } catch {
-    return {};
   }
+
+  const dims = {};
+  for (const [, info] of Object.entries(arrays)) {
+    const za = info.zarray ?? {};
+    const dimNames = (info.zattrs ?? {})._ARRAY_DIMENSIONS ?? [];
+    dimNames.forEach((d, i) => { if (!(d in dims)) dims[d] = za.shape?.[i] ?? 0; });
+  }
+
+  const allVars = {};
+  for (const [name, info] of Object.entries(arrays)) {
+    const za = info.zarray ?? {};
+    const { _ARRAY_DIMENSIONS, ...userAttrs } = info.zattrs ?? {};
+    const dimNames = _ARRAY_DIMENSIONS ?? [];
+    const isTime = dimNames.length === 1 && dimNames[0] === name &&
+      (String(userAttrs.units ?? "").includes("since") || name === "time");
+    allVars[name] = {
+      shape: za.shape ?? [], chunks: za.chunks ?? za.shape ?? [],
+      dtype: parseDtypeStr(za.dtype ?? "|u1"),
+      dims: dimNames, attrs: userAttrs, _isTimeCoord: isTime,
+    };
+  }
+
+  const coordSet = new Set();
+  const splitWords = s => String(s ?? "").split(/[\s,]+/).filter(Boolean);
+  for (const [name, dv] of Object.entries(allVars)) {
+    if (dv.dims.length === 1 && dv.dims[0] === name) coordSet.add(name);
+  }
+  splitWords(attrs.coordinates).forEach(c => coordSet.add(c));
+  for (const dv of Object.values(allVars)) {
+    splitWords(dv.attrs.coordinates).forEach(c => coordSet.add(c));
+  }
+
+  const coords = {}, data_vars = {};
+  for (const [name, dv] of Object.entries(allVars)) {
+    (coordSet.has(name) ? coords : data_vars)[name] = dv;
+  }
+  return { dims, coords, data_vars, attrs };
 }
 
 /**
- * Reads the Retry-After response header and returns the delay in milliseconds.
- * The server sends this on 503 responses when the zarr store is still
- * being built (status: waiting or processing). Falls back to `defaultMs`
- * when the header is absent (500, 404, network errors) or unparseable.
- *
- * The server-side constant _RETRY_AFTER is currently hardcoded to 2 seconds,
- * so in practice this will usually return 2000; but reading it directly
- * means the client automatically adapts if the server value ever changes.
+ * Fetches .zmetadata and returns either:
+ *   { groups: null, ...dataset }; flat store
+ *   { groups: { name → dataset } }; multi-group store
  */
-function retryDelayMs(response, defaultMs) {
-  const header = response.headers.get("Retry-After");
-  if (!header) {
-    return defaultMs;
+async function openDatasetMeta(url) {
+  const base = url.replace(/\/$/, "");
+  let zmeta;
+  try {
+    const token = getTokenFromCookie();
+    const r = await fetch(`${base}/.zmetadata`, {
+      credentials: "same-origin",
+      headers: token ? { Authorization: `${token.token_type} ${token.access_token}` } : {},
+    });
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    zmeta = await r.json();
+  } catch (e) {
+    throw new Error(`Could not read .zmetadata: ${e.message}`);
   }
-  const parsed = parseFloat(header);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed * 1000 : defaultMs;
+
+  const meta = zmeta.metadata ?? {};
+
+  // Detect top-level groups: keys like "group0/.zgroup"
+  const groupNames = new Set();
+  for (const key of Object.keys(meta)) {
+    if (key === ".zgroup" || key === ".zattrs") continue;
+    if (key.endsWith("/.zgroup")) {
+      const name = key.slice(0, -8);
+      if (!name.includes("/")) groupNames.add(name);
+    }
+  }
+
+  if (groupNames.size === 0) {
+    const ds = buildDataset(meta, "");
+    if (!Object.keys({ ...ds.coords, ...ds.data_vars }).length) {
+      throw new Error("No arrays found in .zmetadata");
+    }
+    return { groups: null, ...ds };
+  }
+
+  // Multi-group: build one dataset per group, sorted alphabetically
+  const groups = {};
+  for (const name of [...groupNames].sort()) {
+    groups[name] = buildDataset(meta, `${name}/`);
+  }
+  return { groups };
 }
 
-/**
- * Polls /api/freva-nextgen/data-portal/zarr-utils/html for rendered xarray
- * HTML metadata. Each individual request uses a server-side timeout=1 so it
- * always returns quickly and never blocks the proxy. The hook retries on every
- * non-OK response or network error until `maxAttempts` is reached.
- *
- * On 503 responses the server includes a Retry-After header (currently always
- * 2 s). The hook uses that value as the retry delay when present, falling back
- * to `intervalMs` otherwise.
- *
- * Only activates when `enabled` is true; set enabled={statusCode === 0} so
- * the hook never fires before the zarr conversion job is finished.
- *
- * @param {string|null} rawZarrUrl  The internal zarr URL returned by /zarr/convert.
- * @param {object}      options
- * @param {boolean}     options.enabled      Activate polling (default false).
- * @param {number}      options.intervalMs   Fallback delay between retries in ms (default 2000).
- * @param {number}      options.maxAttempts  Give up after this many tries (default 15).
- *
- * @returns {{ html: string|null, loading: boolean, error: string|null, attempts: number }}
- */
+// xarray HTML renderer
+
+function esc(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+let _uid = 0;
+function uid() { return `xr${++_uid}`; }
+function icon(id) {
+  return `<svg class="icon xr-${id}"><use xlink:href="#${id}"></use></svg>`;
+}
+
+function formatDims(dimSizes, indexedNames) {
+  if (!Object.keys(dimSizes).length) return "";
+  const lis = Object.entries(dimSizes).map(([d, n]) =>
+    `<li><span${indexedNames.has(d) ? " class='xr-has-index'" : ""}>${esc(d)}</span>: ${n}</li>`
+  ).join("");
+  return `<ul class='xr-dim-list'>${lis}</ul>`;
+}
+
+function summarizeAttrs(attrs) {
+  const entries = Object.entries(attrs);
+  if (!entries.length) return "<em>No attributes</em>";
+  return `<dl class='xr-attrs'>${entries.map(([k, v]) =>
+    `<dt><span>${esc(k)} :</span></dt><dd>${esc(String(v))}</dd>`
+  ).join("")}</dl>`;
+}
+
+function previewVar(dv) {
+  const total = dv.shape.reduce((a, b) => a * b, 1);
+  return total === 0 ? "[]" : `${dv.dtype} (${dv.shape.join(" × ")} = ${total.toLocaleString()})`;
+}
+
+function fmtBytes(n) {
+  if (n < 1024) return n + " B";
+  if (n < 1024 ** 2) return (n / 1024).toFixed(2) + " KiB";
+  if (n < 1024 ** 3) return (n / 1024 ** 2).toFixed(2) + " MiB";
+  return (n / 1024 ** 3).toFixed(2) + " GiB";
+}
+
+function buildChunkCube(shape, chunks) {
+  if (!shape.length) return "";
+  const ndim = Math.min(shape.length, 3);
+  const s = shape.slice(-ndim);
+  const vis = n => Math.max(20, Math.min(110, 20 + Math.log10(Math.max(1, n)) * 30));
+  const fmt = n => n.toLocaleString();
+  const fSize = 11;
+  const ts = `font-size:${fSize}px;fill:var(--xr-font-color2);font-family:monospace`;
+
+  if (ndim < 3) {
+    // Flat rectangle for 1-D and 2-D
+    const W = vis(s[ndim - 1]);
+    const H = ndim === 2 ? vis(s[0]) : 12;
+    // room for left label
+    const PAD_LEFT = ndim === 2 ? 42 : 2;
+    const PAD_BTM  = 16;
+    const svgW = PAD_LEFT + W + 4;
+    const svgH = H + PAD_BTM;
+    return `<svg width="${Math.ceil(svgW)}" height="${Math.ceil(svgH)}"
+        viewBox="0 0 ${Math.ceil(svgW)} ${Math.ceil(svgH)}"
+        style="overflow:visible;display:block;flex-shrink:0">
+      <rect x="${PAD_LEFT}" y="0" width="${W}" height="${H}"
+            style="fill:var(--xr-chunk-face);stroke:var(--xr-chunk-edge);stroke-width:0.8"/>
+      ${ndim === 2 ? `<text x="${PAD_LEFT - 5}" y="${H / 2 + 4}"
+            text-anchor="end" style="${ts}">${fmt(s[0])}</text>` : ""}
+      <text x="${PAD_LEFT + W / 2}" y="${H + PAD_BTM - 3}"
+            text-anchor="middle" style="${ts}">${fmt(s[ndim - 1])}</text>
+    </svg>`;
+  }
+
+  // 3-D cube
+  const W = vis(s[2]), H = vis(s[1]), D = vis(s[0]);
+  const sk = 0.5, dX = D * sk, dY = D * sk * 0.45;
+  const PAD_TOP = 16, PAD_BTM = 16, PAD_RGT = 52;
+  const svgW = W + dX + PAD_RGT;
+  const svgH = PAD_TOP + H + dY + PAD_BTM;
+  const ox = 2, oy = PAD_TOP + H + dY;
+  return `<svg width="${Math.ceil(svgW)}" height="${Math.ceil(svgH)}"
+      viewBox="0 0 ${Math.ceil(svgW)} ${Math.ceil(svgH)}"
+      style="overflow:visible;display:block;flex-shrink:0">
+    <polygon points="${ox},${oy} ${ox+W},${oy} ${ox+W},${oy-H} ${ox},${oy-H}"
+             style="fill:var(--xr-chunk-face);stroke:var(--xr-chunk-edge);stroke-width:0.8"/>
+    <polygon points="${ox},${oy-H} ${ox+W},${oy-H} ${ox+W+dX},${oy-H-dY} ${ox+dX},${oy-H-dY}"
+             style="fill:var(--xr-chunk-top);stroke:var(--xr-chunk-edge);stroke-width:0.8"/>
+    <polygon points="${ox+W},${oy} ${ox+W+dX},${oy-dY} ${ox+W+dX},${oy-H-dY} ${ox+W},${oy-H}"
+             style="fill:var(--xr-chunk-side);stroke:var(--xr-chunk-edge);stroke-width:0.8"/>
+    <text x="${ox+W/2}" y="${oy+PAD_BTM-3}"
+          text-anchor="middle" style="${ts}">${fmt(s[2])}</text>
+    <text x="${ox+W/2+dX/2}" y="${PAD_TOP-3}"
+          text-anchor="middle" style="${ts}">${fmt(s[1])}</text>
+    <text x="${ox+W+dX+5}" y="${oy-H/2-dY/2+4}"
+          text-anchor="start" style="${ts}">${fmt(s[0])}</text>
+  </svg>`;
+}
+
+function buildDataRepr(dv) {
+  const { shape, chunks, dtype } = dv;
+  const elemBytes = { int8:1,uint8:1,bool:1,int16:2,uint16:2,int32:4,uint32:4,float32:4,int64:8,uint64:8,float64:8 }[dtype] ?? 4;
+  const arrayBytes = shape.reduce((a, b) => a * b, 1) * elemBytes;
+  let chunkBytes = null, nChunks = null;
+  if (chunks && chunks.length === shape.length) {
+    chunkBytes = chunks.reduce((a, b) => a * b, 1) * elemBytes;
+    nChunks = shape.reduce((tot, s, i) => tot * Math.ceil(s / chunks[i]), 1);
+  }
+  const td0 = `style="color:var(--xr-font-color3);padding:2px 16px 2px 0;white-space:nowrap;vertical-align:top"`;
+  const td1 = `style="padding:2px 16px 2px 0;white-space:nowrap;vertical-align:top"`;
+  const td2 = `style="padding:2px 0;white-space:nowrap;color:var(--xr-font-color2);vertical-align:top"`;
+  const row = (label, arr, chk = "") =>
+    `<tr><td ${td0}>${label}</td><td ${td1}>${arr}</td><td ${td2}>${chk}</td></tr>`;
+  return `<table style="border-collapse:collapse;padding:6px 0 12px"><tr>
+    <td style="vertical-align:top;padding:0">
+      <table style="font-size:12px;font-family:monospace;border-collapse:collapse;line-height:1.75">
+        <thead><tr>
+          <th style="font-weight:400;padding:0 16px 5px 0;text-align:left"></th>
+          <th style="font-weight:600;padding:0 16px 5px 0;text-align:left">Array</th>
+          <th style="font-weight:600;padding:0 0 5px 0;text-align:left">Chunk</th>
+        </tr></thead><tbody>
+          ${row("Bytes", fmtBytes(arrayBytes), chunkBytes !== null ? fmtBytes(chunkBytes) : "—")}
+          ${row("Shape", "("+shape.join(", ")+")", chunks ? "("+chunks.join(", ")+")" : "—")}
+          ${nChunks !== null ? row("Chunks", nChunks.toLocaleString()+" chunks") : ""}
+          ${row("dtype", esc(dtype))}
+          ${row("dims", "("+dv.dims.join(", ")+")")}
+        </tbody>
+      </table>
+    </td>
+    <td style="vertical-align:middle;padding:0 0 0 32px">${buildChunkCube(shape, chunks ?? shape)}</td>
+  </tr></table>`;
+}
+
+function summarizeVariable(name, dv, isIndex) {
+  const aId = uid(), dId = uid();
+  const hasAttrs = Object.keys(dv.attrs).length > 0;
+  return `
+    <div class='xr-var-name'><span${isIndex ? " class='xr-has-index'" : ""}>${esc(name)}</span></div>
+    <div class='xr-var-dims'>(${dv.dims.map(esc).join(", ")})</div>
+    <div class='xr-var-dtype'>${esc(dv.dtype)}</div>
+    <div class='xr-var-preview xr-preview'>${esc(previewVar(dv))}</div>
+    <input id='${aId}' class='xr-var-attrs-in' type='checkbox'${hasAttrs ? "" : " disabled"}>
+    <label for='${aId}' title='Show/Hide attributes'>${icon("icon-file-text2")}</label>
+    <input id='${dId}' class='xr-var-data-in' type='checkbox'>
+    <label for='${dId}' title='Show/Hide data repr'>${icon("icon-database")}</label>
+    <div class='xr-var-attrs'>${summarizeAttrs(dv.attrs)}</div>
+    <div class='xr-var-data'>${buildDataRepr(dv)}</div>
+  `;
+}
+
+function varListHtml(vars, indexedNames) {
+  return `<ul class='xr-var-list'>${
+    Object.entries(vars).map(([name, dv]) =>
+      `<li class='xr-var-item'>${summarizeVariable(name, dv, indexedNames.has(name))}</li>`
+    ).join("")
+  }</ul>`;
+}
+
+function collapsibleSection(header, inline, details, nItems, enabled, collapsed) {
+  const id = uid();
+  const hasItems = nItems > 0;
+  const nSpan = nItems !== null ? ` <span>(${nItems})</span>` : "";
+  const enabledA = enabled && hasItems ? "" : " disabled";
+  const collapsedA = collapsed || !hasItems ? "" : " checked";
+  const tip = enabledA === "" ? " title='Expand/collapse section'" : "";
+  return `
+    <input id='${id}' class='xr-section-summary-in' type='checkbox'${enabledA}${collapsedA} />
+    <label for='${id}' class='xr-section-summary'${tip}>${header}${nSpan}</label>
+    <div class='xr-section-inline-details'>${inline}</div>
+    ${details ? `<div class='xr-section-details'>${details}</div>` : ""}
+  `;
+}
+
+// Xarray SVG icon sprites
+const XR_ICONS = `<svg style="position:absolute;width:0;height:0;overflow:hidden"><defs>
+<symbol id="icon-database" viewBox="0 0 32 32">
+  <path d="M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z"/>
+  <path d="M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"/>
+  <path d="M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z"/>
+</symbol>
+<symbol id="icon-file-text2" viewBox="0 0 32 32">
+  <path d="M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z"/>
+</symbol>
+</defs></svg>`;
+
+function renderDataset(ds) {
+  const coordNames = new Set(Object.keys(ds.coords));
+  const sections = [];
+  sections.push(collapsibleSection("Dimensions:", formatDims(ds.dims, coordNames), "", Object.keys(ds.dims).length, false, true));
+  if (Object.keys(ds.coords).length) {
+    sections.push(collapsibleSection("Coordinates:", "", varListHtml(ds.coords, coordNames), Object.keys(ds.coords).length, true, false));
+  }
+  sections.push(collapsibleSection("Data variables:", "", varListHtml(ds.data_vars, new Set()), Object.keys(ds.data_vars).length, true, false));
+  if (Object.keys(ds.attrs).length) {
+    sections.push(collapsibleSection("Attributes:", "", summarizeAttrs(ds.attrs), Object.keys(ds.attrs).length, true, true));
+  }
+  const sectHtml = sections.map(s => `<li class='xr-section-item'>${s}</li>`).join("");
+  return `<div class='xr-root'>
+    <div class='xr-wrap'>
+      <div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div>
+      <ul class='xr-sections'>${sectHtml}</ul>
+    </div>
+  </div>`;
+}
+
+function buildXarrayRepr(result) {
+  // Flat store
+  if (!result.groups) {
+    return `${XR_ICONS}${renderDataset(result)}`;
+  }
+
+  // Multi-group store
+  const cards = Object.entries(result.groups).map(([name, ds]) => `
+    <details open style="margin-bottom:10px;border:1px solid var(--xr-border-color);border-radius:4px;overflow:hidden">
+      <summary style="padding:8px 12px;font-weight:600;cursor:pointer;background:var(--xr-background-color-row-odd);list-style:none;display:flex;align-items:center;gap:8px">
+        <span style="font-size:11px;color:var(--xr-font-color2)">▶</span>
+        <span>Group: ${esc(name)}</span>
+      </summary>
+      <div style="padding:0 12px 8px">${renderDataset(ds)}</div>
+    </details>
+  `).join("");
+
+  return `${XR_ICONS}<div style="font-family:monospace">${cards}</div>`;
+}
+
+// Inject xarray CSS once (we chose light-themed colors to be
+// compatible with freva's current light theme, but it should look
+// decent in dark mode too)
+
+const XR_CSS = `
+:root {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0,0,0,1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0,0,0,.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0,0,0,.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+.xr-wrap{display:block!important;min-width:300px;max-width:700px;line-height:1.6;padding-bottom:4px}
+.xr-header{padding-top:6px;padding-bottom:6px;border-bottom:solid 1px var(--xr-border-color);margin-bottom:4px}
+.xr-header>div,.xr-header>ul{display:inline;margin-top:0;margin-bottom:0}
+.xr-obj-type,.xr-obj-name{margin-left:2px;margin-right:10px}
+.xr-obj-type{color:var(--xr-font-color2)}
+.xr-sections{padding-left:0!important;display:grid;grid-template-columns:150px auto auto 1fr 0 20px 0 20px;margin-block-start:0;margin-block-end:0}
+.xr-section-item{display:contents}
+.xr-section-item>input,.xr-var-item>input{display:block;opacity:0;height:0;margin:0}
+.xr-section-item>input+label,.xr-var-item>input+label{color:var(--xr-disabled-color)}
+.xr-section-item>input:enabled+label,.xr-var-item>input:enabled+label{cursor:pointer;color:var(--xr-font-color2)}
+.xr-section-item>input:enabled+label:hover,.xr-var-item>input:enabled+label:hover{color:var(--xr-font-color0)}
+.xr-section-summary{grid-column:1;color:var(--xr-font-color2);font-weight:500;white-space:nowrap}
+.xr-section-summary>span{display:inline-block;padding-left:.3em}
+.xr-section-summary-in:disabled+label{color:var(--xr-font-color2)}
+.xr-section-summary-in+label:before{display:inline-block;content:"►";font-size:11px;width:15px;text-align:center}
+.xr-section-summary-in:disabled+label:before{color:var(--xr-disabled-color)}
+.xr-section-summary-in:checked+label:before{content:"▼"}
+.xr-section-summary-in:checked+label>span{display:none}
+.xr-section-summary,.xr-section-inline-details{padding-top:4px}
+.xr-section-inline-details{grid-column:2/-1}
+.xr-section-details{grid-column:1/-1;margin-top:4px;margin-bottom:5px}
+.xr-section-summary-in~.xr-section-details{display:none}
+.xr-section-summary-in:checked~.xr-section-details{display:contents}
+.xr-array-wrap{grid-column:1/-1;display:grid;grid-template-columns:20px auto}
+.xr-array-wrap>label{grid-column:1;vertical-align:top}
+.xr-preview{color:var(--xr-font-color3)}
+.xr-array-preview,.xr-array-data{padding:0 5px!important;grid-column:2}
+.xr-array-data,.xr-array-in:checked~.xr-array-preview{display:none}
+.xr-array-in:checked~.xr-array-data,.xr-array-preview{display:inline-block}
+.xr-dim-list{display:inline-block!important;list-style:none;padding:0!important;margin:0}
+.xr-dim-list li{display:inline-block;padding:0;margin:0}
+.xr-dim-list:before{content:"("}
+.xr-dim-list:after{content:")"}
+.xr-dim-list li:not(:last-child):after{content:",";padding-right:5px}
+.xr-has-index{font-weight:bold}
+.xr-var-list,.xr-var-item{display:contents}
+.xr-var-item>div,.xr-var-item label,.xr-var-item>.xr-var-name span{background-color:var(--xr-background-color-row-even);border-color:var(--xr-background-color-row-odd);margin-bottom:0;padding-top:2px}
+.xr-var-list>li:nth-child(odd)>div,.xr-var-list>li:nth-child(odd)>label,.xr-var-list>li:nth-child(odd)>.xr-var-name span{background-color:var(--xr-background-color-row-odd);border-color:var(--xr-background-color-row-even)}
+.xr-var-name{grid-column:1}
+.xr-var-dims{grid-column:2}
+.xr-var-dtype{grid-column:3;text-align:right;color:var(--xr-font-color2)}
+.xr-var-preview{grid-column:4}
+.xr-index-preview{grid-column:2/5;color:var(--xr-font-color2)}
+.xr-var-name,.xr-var-dims,.xr-var-dtype,.xr-preview,.xr-attrs dt{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;padding-right:10px}
+.xr-var-name:hover,.xr-var-dims:hover,.xr-var-dtype:hover,.xr-attrs dt:hover{overflow:visible;width:auto;z-index:1}
+.xr-var-attrs,.xr-var-data,.xr-index-data{display:none;border-top:2px dotted var(--xr-background-color);padding-bottom:20px!important;padding-top:10px!important}
+.xr-var-attrs-in:checked~.xr-var-attrs,.xr-var-data-in:checked~.xr-var-data{display:block}
+.xr-var-data>table{float:right}
+.xr-var-data>pre,.xr-var-data>table>tbody>tr{background-color:transparent!important}
+.xr-var-name span,.xr-var-data,.xr-attrs{padding-left:25px!important}
+.xr-attrs,.xr-var-attrs,.xr-var-data,.xr-index-data{grid-column:1/-1}
+dl.xr-attrs{padding:0;margin:0;display:grid;grid-template-columns:125px auto}
+.xr-attrs dt,.xr-attrs dd{padding:0;margin:0;float:left;padding-right:10px;width:auto}
+.xr-attrs dt{font-weight:normal;grid-column:1}
+.xr-attrs dd{grid-column:2;white-space:pre-wrap;word-break:break-all}
+.xr-icon-database,.xr-icon-file-text2{display:inline-block;vertical-align:middle;width:1em;height:1.5em!important;stroke-width:0;stroke:currentColor;fill:currentColor}
+.xr-var-attrs-in:checked+label>.xr-icon-file-text2,.xr-var-data-in:checked+label>.xr-icon-database{color:var(--xr-font-color0);filter:drop-shadow(1px 1px 5px var(--xr-font-color2));stroke-width:.8px}
+.xr-var-item>input+label{cursor:pointer;color:var(--xr-font-color2);padding:0 1px}
+`;
+
+let cssInjected = false;
+function injectXarrayCss() {
+  if (cssInjected) return;
+  cssInjected = true;
+
+  const hex = (window.MAIN_COLOR || "#9b7a52").replace(/^#/, "");
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  const cl = f => `rgb(${Math.min(255,r*f|0)},${Math.min(255,g*f|0)},${Math.min(255,b*f|0)})`;
+  const ca = (f, a) => `rgba(${Math.min(255,r*f|0)},${Math.min(255,g*f|0)},${Math.min(255,b*f|0)},${a})`;
+
+  const chunkVars = `
+    :root{--xr-chunk-face:${cl(0.85)};--xr-chunk-top:${cl(1.25)};--xr-chunk-side:${cl(0.55)};--xr-chunk-edge:${cl(0.25)}}
+    html[data-theme="dark"],body[data-theme="dark"],body.vscode-dark{
+      --xr-chunk-face:${ca(0.85,.65)};--xr-chunk-top:${ca(1.25,.65)};--xr-chunk-side:${ca(0.55,.65)};--xr-chunk-edge:${ca(0.25,.4)}
+    }
+  `;
+
+  const style = document.createElement("style");
+  style.setAttribute("data-xarray-repr", "1");
+  style.textContent = chunkVars + XR_CSS;
+  document.head.appendChild(style);
+}
+
+// Hook to fetch .zmetadata and build an HTML representation
+// of the dataset using xarray's style.
+// it fires only after the zarr conversion job is done
 export function useHtmlMetadata(
   rawZarrUrl,
-  { enabled = false, intervalMs = 2000, maxAttempts = 15 } = {}
+  { enabled = false } = {}
 ) {
   const [html, setHtml] = useState(null);
   const [error, setError] = useState(null);
@@ -78,70 +462,23 @@ export function useHtmlMetadata(
     setHtml(null);
     setError(null);
 
-    if (!rawZarrUrl || !enabled) {
-      return () => {};
-    }
+    if (!rawZarrUrl || !enabled) return () => {};
+
+    injectXarrayCss();
 
     let cancelled = false;
-    let attemptCount = 0;
-    let timerId = null;
 
-    async function poll() {
-      if (cancelled) {
-        return;
-      }
-
-      if (attemptCount >= maxAttempts) {
-        if (!cancelled) {
-          setError(
-            `Metadata not ready after ${maxAttempts} attempts — try reloading the file.`
-          );
-        }
-        return;
-      }
-
-      attemptCount += 1;
-
+    (async () => {
       try {
-        const res = await fetch(
-          `/api/freva-nextgen/data-portal/zarr-utils/html?url=${encodeURIComponent(rawZarrUrl)}&timeout=1`,
-          {
-            credentials: "same-origin",
-            headers: getAuthHeaders(),
-          }
-        );
-
-        if (res.ok) {
-          const text = await res.text();
-          if (!cancelled) {
-            setHtml(text);
-          }
-          return;
-        }
-
-        // Non-OK response; use Retry-After when the server sends it (503),
-        // fall back to intervalMs for everything else (500, 404, etc.).
-        const delay = retryDelayMs(res, intervalMs);
-        if (!cancelled) {
-          timerId = setTimeout(poll, delay);
-        }
-      } catch {
-        // Network error; no response headers available, use fixed fallback.
-        if (!cancelled) {
-          timerId = setTimeout(poll, intervalMs);
-        }
+        const ds = await openDatasetMeta(rawZarrUrl);
+        if (!cancelled) setHtml(buildXarrayRepr(ds));
+      } catch (e) {
+        if (!cancelled) setError(e.message);
       }
-    }
+    })();
 
-    poll();
-
-    return () => {
-      cancelled = true;
-      if (timerId) {
-        clearTimeout(timerId);
-      }
-    };
-  }, [rawZarrUrl, enabled, intervalMs, maxAttempts]);
+    return () => { cancelled = true; };
+  }, [rawZarrUrl, enabled]);
 
   return { html, error };
 }

--- a/assets/js/Containers/Databrowser/FilesPanel.js
+++ b/assets/js/Containers/Databrowser/FilesPanel.js
@@ -21,6 +21,7 @@ import Pagination from "../../Components/Pagination";
 
 import { useZarrStatus } from "../../Components/NcdumpDialog/useZarrStatus";
 import { useHtmlMetadata } from "../../Components/NcdumpDialog/useHtmlMetadata";
+import { detectZarrStore } from "../../Components/NcdumpDialog/detectZarrStore";
 
 import { BATCH_SIZE } from "./constants";
 
@@ -30,25 +31,21 @@ function FilesPanelImpl(props) {
   const { files, numFiles, fileLoading } = props.databrowser;
   const [showDialog, setShowDialog] = useState(false);
   const [rawZarrUrl, setRawZarrUrl] = useState(null);
+  const [isDirectZarr, setIsDirectZarr] = useState(false);
   const [ncdump, setNcDump] = useState({
     status: NcDumpDialogState.READY,
     output: null,
     error: null,
   });
 
-  // Zarr conversion status polling
-  // Polls /zarr-utils/status endpoint until the conversion job reaches a terminal state.
   const { statusCode, statusReason } = useZarrStatus(rawZarrUrl, {
-    enabled: showDialog,
+    enabled: showDialog && !isDirectZarr,
   });
 
-  // HTML metadata polling
-  // Only activates once the zarr job is done (statusCode === 0).
-  // Each fetch uses server-side timeout=1 so no single request can block the
-  // proxy; the hook retries automatically until it gets a 200 or exhausts
-  // maxAttempts.
+  // Only activates once the zarr job is done (statusCode === 0),
+  // or immediately if the URL was already a zarr store.
   const { html: htmlMetadata, error: htmlError } = useHtmlMetadata(rawZarrUrl, {
-    enabled: statusCode === 0,
+    enabled: isDirectZarr || statusCode === 0,
   });
 
   // React to zarr job failure interpretaion
@@ -174,6 +171,22 @@ function FilesPanelImpl(props) {
       };
 
       const paths = Array.isArray(fn) ? fn : [fn];
+      const hasAggConfig =
+        aggregationConfig &&
+        Object.values(aggregationConfig).some((v) => v !== null && v !== "");
+
+      // Skip conversion for a single remote zarr URL with no active
+      // aggregation parameters
+      if (paths.length === 1 && paths[0].startsWith("http") && !hasAggConfig) {
+        const { isZarr } = await detectZarrStore(paths[0]);
+        if (isZarr) {
+          setIsDirectZarr(true);
+          setRawZarrUrl(paths[0]);
+          return;
+        }
+      }
+      setIsDirectZarr(false);
+
       const requestBody = {
         path: paths.length === 1 ? paths[0] : paths,
         ...(aggregationConfig

--- a/assets/js/Containers/Inspect/index.js
+++ b/assets/js/Containers/Inspect/index.js
@@ -211,15 +211,20 @@ function InspectPage({ location, router }) {
         throw new Error("Authentication required. Please refresh your token.");
       }
 
-      // If fn is a remote URL already pointing to a zarr store,
-      // skip conversion
-      const path = Array.isArray(fn) ? fn[0] : fn;
-      if (path.startsWith("http")) {
-        const { isZarr } = await detectZarrStore(path);
+      // Skip conversion only for a single remote zarr URL with no active
+      // aggregation parameters. Multi-file arrays and any aggregation config
+      // (time range, level, etc.) always go through the data-loader.
+      const paths = Array.isArray(fn) ? fn : [fn];
+      const hasAggConfig =
+        aggregationConfig &&
+        Object.values(aggregationConfig).some((v) => v !== null && v !== "");
+
+      if (paths.length === 1 && paths[0].startsWith("http") && !hasAggConfig) {
+        const { isZarr } = await detectZarrStore(paths[0]);
         if (isZarr) {
           setIsDirectZarr(true);
-          setRawZarrUrl(path);
-          setZarrUrl(path);
+          setRawZarrUrl(paths[0]);
+          setZarrUrl(paths[0]);
           return;
         }
       }

--- a/assets/js/Containers/Inspect/index.js
+++ b/assets/js/Containers/Inspect/index.js
@@ -625,8 +625,8 @@ function InspectPage({ location, router }) {
           </div>
         </div>
 
-        {/* Zarr URL strip */}
-        {zarrUrl && (
+        {/* only shown zarr URL for converted URLs, not direct zarr input */}
+        {zarrUrl && !isDirectZarr && (
           <div style={styles.zarrStrip}>
             <i
               className="fas fa-link"

--- a/assets/js/Containers/Inspect/index.js
+++ b/assets/js/Containers/Inspect/index.js
@@ -8,6 +8,7 @@ import { ZarrLoadingSteps } from "../../Components/NcdumpDialog/ZarrLoadingSteps
 import { NcDumpDialogState } from "../../Components/NcdumpDialog";
 import { useZarrStatus } from "../../Components/NcdumpDialog/useZarrStatus";
 import { useHtmlMetadata } from "../../Components/NcdumpDialog/useHtmlMetadata";
+import { detectZarrStore } from "../../Components/NcdumpDialog/detectZarrStore";
 import {
   getCookie,
   getTokenFromCookie,
@@ -115,20 +116,18 @@ function InspectPage({ location, router }) {
   });
   const [zarrUrl, setZarrUrl] = useState(null);
   const [rawZarrUrl, setRawZarrUrl] = useState(null);
+  const [isDirectZarr, setIsDirectZarr] = useState(false);
   const [currentFile, setCurrentFile] = useState(initialFilename);
   const [currentIsAgg, setCurrentIsAgg] = useState(isAggregation);
 
-  // Zarr conversion status polling
   const { statusCode, statusReason } = useZarrStatus(rawZarrUrl, {
-    enabled: true,
+    enabled: !isDirectZarr,
   });
 
-  // HTML metadata polling
-  // Only activates once the zarr job is done (statusCode === 0).
-  // Each individual fetch uses server-side timeout=1 so no single request
-  // can block the proxy; retries automatically until content arrives.
+  // Only activates once the zarr job is done (statusCode === 0),
+  // or immediately if the URL was already a zarr store.
   const { html: htmlMetadata, error: htmlError } = useHtmlMetadata(rawZarrUrl, {
-    enabled: statusCode === 0,
+    enabled: isDirectZarr || statusCode === 0,
   });
 
   const abortRef = useRef(null);
@@ -211,6 +210,20 @@ function InspectPage({ location, router }) {
       if (!tokenData?.access_token) {
         throw new Error("Authentication required. Please refresh your token.");
       }
+
+      // If fn is a remote URL already pointing to a zarr store,
+      // skip conversion
+      const path = Array.isArray(fn) ? fn[0] : fn;
+      if (path.startsWith("http")) {
+        const { isZarr } = await detectZarrStore(path);
+        if (isZarr) {
+          setIsDirectZarr(true);
+          setRawZarrUrl(path);
+          setZarrUrl(path);
+          return;
+        }
+      }
+      setIsDirectZarr(false);
 
       const headers = {
         "X-CSRFToken": getCookie("csrftoken"),

--- a/assets/js/Containers/Inspect/index.js
+++ b/assets/js/Containers/Inspect/index.js
@@ -236,7 +236,6 @@ function InspectPage({ location, router }) {
         Authorization: `Bearer ${tokenData.access_token}`,
       };
 
-      const paths = Array.isArray(fn) ? fn : [fn];
       const requestBody = {
         path: paths.length === 1 ? paths[0] : paths,
         ...(aggregationConfig

--- a/assets/js/Containers/Inspect/index.js
+++ b/assets/js/Containers/Inspect/index.js
@@ -329,7 +329,7 @@ function InspectPage({ location, router }) {
   }
 
   function addPathInput() {
-    setPathInputs((prev) => [...prev, ""]);
+    setPathInputs((prev) => (prev.length < 10 ? [...prev, ""] : prev));
   }
 
   function removePathInput(index) {
@@ -539,9 +539,13 @@ function InspectPage({ location, router }) {
           >
             <button
               onClick={addPathInput}
-              disabled={isLoading}
+              disabled={isLoading || pathInputs.length >= 10}
               style={styles.addBtn}
-              title="Add another file path to aggregate"
+              title={
+                pathInputs.length >= 10
+                  ? "Maximum of 10 files reached"
+                  : "Add another file path to aggregate"
+              }
             >
               <i className="fas fa-plus me-2" />
               Add file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evaluation_system_web",
-  "version": "2605.0.0",
+  "version": "2605.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "evaluation_system_web",
-      "version": "2605.0.0",
+      "version": "2605.1.0",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^2.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evaluation_system_web",
-  "version": "2605.0.0",
+  "version": "2605.1.0",
   "description": "React-bits of the freva-web interface. The react-parts of the web interface include the plugin-selection, the data-browser and the result-browser",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Following a discussion with @antarcticrainforest, the goal was to allow files that are already zarr on the cloud to skip the conversion pipeline entirely. That means, no dataloader job, and just a direct URL. The blocker was that the metadata viewer required the server to open the dataset and call xarray's html output, which meant every file had to go through the dataloader regardless.
This PR removes that dependency. The xarray HTML output is now built entirely client-side from `.zmetadata`, `.zarray`, and `.zattrs`. The `/zarr-utils/html` endpoint is no longer called from the frontend.
As a result, any zarr URL, whether freshly converted or already on the cloud, can serve the metadata view with a single lightweight fetch, and the `/html` endpoint on dataloader server is no longer in the critical path for this feature.
One PR on the freva-nextgen is left to be able to ditch`/html` endpoint and also skip the already `zarr` data on the cloud from going to the data-loader conversion procedure.
It has been already deployed here:
https://freva-deployment.dkrz.de/inspect?file=%2Fwork%2Fkd0956%2FCORDEX%2Fdata%2Fcordex%2Foutput%2FWAS-44%2FSMHI%2FNOAA-GFDL-GFDL-ESM2M%2Frcp85%2Fr1i1p1%2FSMHI-RCA4%2Fv2%2Fday%2Fvas%2Fv20201110%2Fvas_WAS-44_NOAA-GFDL-GFDL-ESM2M_rcp85_r1i1p1_SMHI-RCA4_v2_day_20960101-21001231.nc

FYI @antarcticrainforest 