### PR TITLE
fix: restore dynamic color on password modal header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [v2605.1.1]
+### Fixed
+- Fix the default MAIN_COLOR missing in plugin setup
 ## [v2605.1.0]
 ### Removed
 - Remove `/zarr-utils/html` endpoint and render xarray metadata client-side

--- a/base/templatetags/settingstags.py
+++ b/base/templatetags/settingstags.py
@@ -5,11 +5,15 @@ register = template.Library()
 
 
 @register.simple_tag
-def settings_val(value):
+def settings_val(value, default=""):
     """
-    Returns a variable from the settings
+    Returns a variable from the settings.
+    Falls back to ``default`` if the setting is missing or evaluates to None.
     """
-    return str(getattr(settings, value))
+    result = getattr(settings, value, None)
+    if result is None:
+        return default
+    return str(result)
 
 
 @register.simple_tag

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evaluation_system_web",
-  "version": "2605.1.0",
+  "version": "2605.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "evaluation_system_web",
-      "version": "2605.1.0",
+      "version": "2605.1.1",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^2.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evaluation_system_web",
-  "version": "2605.1.0",
+  "version": "2605.1.1",
   "description": "React-bits of the freva-web interface. The react-parts of the web interface include the plugin-selection, the data-browser and the result-browser",
   "main": "index.js",
   "engines": {

--- a/templates/plugins/setup.html
+++ b/templates/plugins/setup.html
@@ -52,7 +52,8 @@
             animation: freva-modal-in 0.22s ease;
         }
         .freva-modal-header {
-            background: linear-gradient(135deg, {% settings_val 'MAIN_COLOR' %} 0%, {% settings_val 'HOVER_COLOR' %} 100%);
+            background-color: {% settings_val 'MAIN_COLOR' %};
+            background-image: linear-gradient(135deg, {% settings_val 'MAIN_COLOR' %} 0%, {% settings_val 'HOVER_COLOR' %} 100%);
             color: #fff;
             padding: 14px 20px;
             position: relative;


### PR DESCRIPTION
The `.freva-modal-header` gradient was silently dropped by the browser whenever `HOVER_COLOR` was missing from settings, leaving the header transparent and its white text invisible. The submit button was unaffected because it only references `MAIN_COLOR`.

- Split `background` shorthand into `background-color` (solid fallback) + `background-image` (gradient) so the header always shows the primary brand color even if the gradient is invalid
- Also updated `settings_val` template tag to accept a `default` argument and use `getattr(settings, value, None)` instead of raising `AttributeError` on missing keys