### PR TITLE
Hotfix: disable shared repo for mamba to until upstream micromamba fixes the regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [v2605.2.1]
+### Fixed
+- CI: Opt out MAMBA_USE_SHARDED_REPODATA in dockerfile until upstream micromamba fixes the regression
 ## [v2605.2.0]
 ### Fixed
 - Dataloader: percent-encoded URLs, dev-env CORS, FilesPanel parity for data-loader endpoints, metadata cube visibility

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,13 +48,17 @@ RUN set -eu \
     --shell /usr/sbin/nologin \
     nobody
 
-
-
 RUN  set -exu && \
      sed -i "s|\"path\": \"${BUNDLE_HOST_PATH}|\"path\": \"${FREVA_WEB_DIR}|g" \
      ${FREVA_WEB_DIR}/webpack-stats.json &&\
      mkdir -p /data/logs ./base/migrations && chmod 1777 -R /data ./base/migrations
 
+# Disable sharded repodata. micromamba 2.6.x enabled it by default; on envs
+# with a heavy transitive graph (freva pulls pandas/xarray/ffmpeg/openvino/…)
+# "Resolving Environment" goes from 25s to 3h.
+# Opt-out documented at: https://github.com/mamba-org/mamba/releases/tag/2.6.0
+# Drop once upstream micromamba fixes the regression.
+ENV MAMBA_USE_SHARDED_REPODATA=false
 RUN  set -exu && \
      micromamba env create -y -q -n freva-web -f conda-env.yml && \
      micromamba run -n freva-web python -m pip cache purge --no-input -q &&\

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evaluation_system_web",
-  "version": "2605.2.0",
+  "version": "2605.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "evaluation_system_web",
-      "version": "2605.2.0",
+      "version": "2605.2.1",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^2.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evaluation_system_web",
-  "version": "2605.2.0",
+  "version": "2605.2.1",
   "description": "React-bits of the freva-web interface. The react-parts of the web interface include the plugin-selection, the data-browser and the result-browser",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Container builds started taking around 3 hours instead of 1 minute. Root cause is a regression in `micromamba 2.6.x`, which enables "sharded repodata" by default. On envs with a heavy transitive graph (like our `freva` pulls in pandas/xarray/ffmpeg/openvino) the per-shard reachability walk serializes HTTP fetches and the solver step blows up. This PR opts out via `MAMBA_USE_SHARDED_REPODATA=false` in both the Dockerfile for time being.
Everything is now back to previous 10 mins CI. this PR would be merged as soon as the CI becomes green

FYI @antarcticrainforest 