### PR TITLE
hotfix STACBROWSER setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ setup-stacbrowser:
 	@if [ ! -d "stac-browser" ]; then \
 		git clone https://github.com/radiantearth/stac-browser.git stac-browser; \
 	fi
-	cd stac-browser && git checkout -- src/init.js vite.config.js config.js
+	cd stac-browser && git fetch origin && git reset --hard origin/main && git clean -fd
 	cd stac-browser && patch -p1 --forward < ../stac-browser-patches/stac-browser-init.patch
 	cd stac-browser && patch -p1 --forward < ../stac-browser-patches/stac-browser-vite.patch
 	cd stac-browser && python3 -c "\


### PR DESCRIPTION
`make setup-stacbrowser` could fail or behave inconsistently depending on the state of a developer's local `stac-browser/` checkout. If the clone is old, the expected vite files aren't present and the build fails. This PR fixes that for the dev environment only;
production is unaffected, since it clones and builds fresh every time.