### PR TITLE
Render Markdown in blurbs.

### DIFF
--- a/.github/workflows/test_job.yml
+++ b/.github/workflows/test_job.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build node code
         run: |
-          npm install
+          npm ci
           npm run build-production
 
       - name: Build freva-web image for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-## [v2606.0.0]
+## [v2606.0.1]
 ### Added
 - Support for Markdown based blurbs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 ## [v2606.0.0]
+### Added
+- Support for Markdown based blurbs
+
+## [v2606.0.0]
 ### Changed
 - Do not request oidc scopes from token endpoints
 

--- a/base/templatetags/homepage_text.py
+++ b/base/templatetags/homepage_text.py
@@ -1,0 +1,46 @@
+import bleach
+import markdown
+
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+ALLOWED_TAGS = {
+    "p",
+    "br",
+    "strong",
+    "em",
+    "a",
+    "ul",
+    "ol",
+    "li",
+    "code",
+}
+
+ALLOWED_ATTRIBUTES = {
+    "a": ["href", "title", "target", "rel"],
+}
+
+ALLOWED_PROTOCOLS = ["http", "https", "mailto"]
+
+
+@register.filter
+def render_homepage_text(value: str) -> str:
+    html = markdown.markdown(
+        value or "",
+        extensions=["nl2br"],
+        output_format="html5",
+    )
+
+    cleaned = bleach.clean(
+        html,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRIBUTES,
+        protocols=ALLOWED_PROTOCOLS,
+        strip=True,
+    )
+
+    cleaned = bleach.linkify(cleaned)
+
+    return mark_safe(cleaned)

--- a/base/templatetags/homepage_text.py
+++ b/base/templatetags/homepage_text.py
@@ -1,6 +1,5 @@
 import bleach
 import markdown
-
 from django import template
 from django.utils.safestring import mark_safe
 

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -12,6 +12,7 @@ dependencies:
   - freva
   - git
   - gunicorn
+  - markdown
   - mysql-client <9
   - mysqlclient
   - paramiko
@@ -28,4 +29,3 @@ dependencies:
       - django-bootstrap-v5
       - django-model-utils
       - djproxy
-

--- a/django_evaluation/settings/local.py
+++ b/django_evaluation/settings/local.py
@@ -133,17 +133,17 @@ _set_favicon(MAIN_COLOR, Path(PROJECT_ROOT))
 BORDER_COLOR = _get_conf_key(web_config, "border_color", "#6c2e1f", False)
 HOVER_COLOR = _get_conf_key(web_config, "hover_color", "#d0513a", False)
 HOMEPAGE_TEXT = web_config.get("homepage_text") or (
-    "Lorem ipsum dolor sit amet"
+    "[*Lorem ipsum*](https://www.lipsum.com) dolor sit amet"
     ", consectetur adipiscing elit"
     ", sed do eiusmod tempor incididunt ut"
     "labore et dolore magna aliqua. Ut enim"
     "ad minim veniam, quis nostrud exercitation"
     "ullamco laboris nisi ut aliquip ex ea commodo"
-    "consequat. Duis aute irure dolor in reprehenderit"
+    "consequat.\n\n Duis aute irure dolor in reprehenderit"
     "in voluptate velit esse cillum dolore eu fugiat"
     "nulla pariatur. Excepteur sint occaecat cupidatat"
     "non proident, sunt in culpa qui officia deserunt"
-    "mollit anim id est laborum."
+    "mollit anim **id est laborum**."
 )
 IMPRINT = web_config.get("imprint") or [
     "ANAIS - RegIKlim",
@@ -152,7 +152,7 @@ IMPRINT = web_config.get("imprint") or [
     "20146 Hamburg",
     "Germany",
 ]
-HOMEPAGE_HEADING = web_config.get("homepage_heading") or "Lorem ipsum dolor."
+HOMEPAGE_HEADING = web_config.get("homepage_heading") or "Lorem ipsum dolor"
 ABOUT_US_TEXT = web_config.get("about_us_text") or "Hello world, this is freva."
 CONTACTS = web_config.get("contacts") or ["freva@dkrz.de"]
 DEFAULT_FLAVOUR = (
@@ -334,7 +334,11 @@ for title, url, html_id in web_config.get("menu_entries", []) or _MENU_ENTRIES:
             {"name": title, "url": reverse_lazy(url), "html_id": html_id}
         )
 MENU_ENTRIES.append(
-    {"name": "Data-Inspect", "url": reverse_lazy("solr:inspect"), "html_id": "inspect_menu"}
+    {
+        "name": "Data-Inspect",
+        "url": reverse_lazy("solr:inspect"),
+        "html_id": "inspect_menu",
+    }
 )
 if ACTIVATE_CHAT_BOT:
     MENU_ENTRIES.append(

--- a/django_evaluation/settings/local.py
+++ b/django_evaluation/settings/local.py
@@ -335,7 +335,7 @@ for title, url, html_id in web_config.get("menu_entries", []) or _MENU_ENTRIES:
         )
 MENU_ENTRIES.append(
     {
-        "name": "Data-Inspect",
+        "name": "Data-Viewer",
         "url": reverse_lazy("solr:inspect"),
         "html_id": "inspect_menu",
     }
@@ -343,7 +343,7 @@ MENU_ENTRIES.append(
 if ACTIVATE_CHAT_BOT:
     MENU_ENTRIES.append(
         {
-            "name": "FrevaGPT",
+            "name": "Climate-Claw",
             "url": reverse_lazy("bot:chatbot"),
             "html_id": "chatbot_menu",
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evaluation_system_web",
-  "version": "2605.2.2",
+  "version": "2606.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "evaluation_system_web",
-      "version": "2605.2.2",
+      "version": "2606.0.1",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^2.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evaluation_system_web",
-  "version": "2606.0.0",
+  "version": "2606.0.1",
   "description": "React-bits of the freva-web interface. The react-parts of the web interface include the plugin-selection, the data-browser and the result-browser",
   "main": "index.js",
   "engines": {

--- a/templates/_layouts/base.html
+++ b/templates/_layouts/base.html
@@ -1,5 +1,7 @@
 {% load bootstrap5 %}
 {% load settingstags %}
+{% load homepage_text %}
+
 
 <!doctype html>
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->

--- a/templates/base/home.html
+++ b/templates/base/home.html
@@ -1,4 +1,5 @@
 {% extends "_layouts/menu.html" %}
+{% load homepage_text %}
 
 {% block page_title %}Evaluation System{% endblock %}
 {% block page_class %}home-page{% endblock %}
@@ -96,22 +97,24 @@
     <div class="container mb-3">
         <!-- Service starts -->
         <div class="row services-container">
-            <!-- Service #1 -->
             <div class="services-item card shadow p-3 my-3 bg-light">
-                <h5>{% settings_val 'HOMEPAGE_HEADING'%}</h5>
+                {% settings_val 'HOMEPAGE_HEADING' as homepage_heading %}
+                {% settings_val 'HOMEPAGE_TEXT' as homepage_text %}
+                <h5>{{ homepage_heading }}</h5>
                 <hr class="border-dark"/>
-                <p align="justify">{% settings_val 'HOMEPAGE_TEXT'%}</p>
+                <div class="homepage-text" style="text-align: justify;">
+                    {{ homepage_text|render_homepage_text }}
+                </div>
             </div>
             <!-- Service #2 -->
             <div class="services-item card shadow p-3 my-3 bg-light">
                 <h5>Freva - Free Evaluation System Framework</h5>
                 <hr class="border-dark"/>
                 <p align="justify">
-                    The Climate Informatics and Technologies research group provides a standardized data and evaluation system -
-                    developed at the DKRZ and FUB in Germany. Freva provides efficient and
+                The Data Analysis Infrastructure team at <a href=https://www.dkrz.de/>DKRZ</a>
+                provides a standardized data and evaluation system - developed at the DKRZ and FUB in Germany. Freva provides efficient and
                     comprehensive access to the model data base as well as to evaluation data sets.
-                    The application system is developed as an easy to use
-                    low-end application minimizing technical requirements for users and tool developers.
+                    The application system is developed as an easy to use low-end application minimizing technical requirements for users and tool developers.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
Because of security concerns only pure text strings were allowed in the home pages blurbs. 

This PR enables Markdown based rendering allowing for a minimal set of slightly more elaborate text rendering while trying to keep the system safe. 

Displaying external links, line breaks, bold, recursive is now supported via simple markdown text.

@eelucio FYI, @Karinon I hope this doesn't affect your security concerns. 