### PR TITLE
Hotfix: patch a bug in STAC Browser that crash from undefined catch-all route param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [v2606.0.2]
+### Added
+- STAC-Browser: Fix `startsWith` on undefined route param via new router guard patch
 ## [v2606.0.1]
 ### Added
 - Support for Markdown based blurbs

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ setup-stacbrowser:
 	cd stac-browser && git fetch origin && git reset --hard origin/main && git clean -fd
 	cd stac-browser && patch -p1 --forward < ../stac-browser-patches/stac-browser-init.patch
 	cd stac-browser && patch -p1 --forward < ../stac-browser-patches/stac-browser-vite.patch
+	cd stac-browser && patch -p1 --forward < ../stac-browser-patches/stac-browser-router-guard.patch
 	cd stac-browser && python3 -c "\
 import pathlib; \
 p = pathlib.Path('config.js'); \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evaluation_system_web",
-  "version": "2606.0.1",
+  "version": "2606.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "evaluation_system_web",
-      "version": "2606.0.1",
+      "version": "2606.0.2",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^2.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evaluation_system_web",
-  "version": "2606.0.1",
+  "version": "2606.0.2",
   "description": "React-bits of the freva-web interface. The react-parts of the web interface include the plugin-selection, the data-browser and the result-browser",
   "main": "index.js",
   "engines": {

--- a/stac-browser-patches/stac-browser-router-guard.patch
+++ b/stac-browser-patches/stac-browser-router-guard.patch
@@ -1,0 +1,10 @@
+--- a/src/router/index.js
++++ b/src/router/index.js
+@@ -1,6 +1,6 @@
+ function catchAllString(route) {
+   const pathMatch = route.params.pathMatch;
+-  return Array.isArray(pathMatch) ? pathMatch.join("/") : pathMatch;
++  return Array.isArray(pathMatch) ? pathMatch.join("/") : (pathMatch ?? "");
+ }
+ 
+ function getPath(route, config) {


### PR DESCRIPTION
The embedded STAC Browser crashes at runtime with `TypeError: can't access property "startsWith", n is undefined`. The error originates upstream in `src/router/index.js: catchAllString()` returns undefined when `route.params.pathMatch` is missing, and the catch-all route's props function then calls `.startsWith()` on that undefined value.
This is basically a bug on their side. The proper fix is a PR against STAC Browser, which we'll open upstream when we have time. For now, the low-hanging fruit is to carry a guard patch here and even if they fix this, this patch guard becomes harmless.

FYI @antarcticrainforest 