### PR TITLE
fix: don't send Freva token when probing external zarr stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+##[v2607.0.0]
+### Fixed
+- Inspector: Don't send Freva token when probing external zarr stores
 ##[v2606.0.4]
 ### Changed
 - Adapted shortcut to toggle bot model select

--- a/assets/js/Components/NcdumpDialog/detectZarrStore.js
+++ b/assets/js/Components/NcdumpDialog/detectZarrStore.js
@@ -9,7 +9,9 @@ import { getTokenFromCookie, normalizeUrl } from "../../utils";
  */
 function isSameOrigin(base) {
   try {
-    return new URL(base, window.location.origin).origin === window.location.origin;
+    return (
+      new URL(base, window.location.origin).origin === window.location.origin
+    );
   } catch {
     // If it does not parse as a URL, treat it as a relative/same-origin path.
     return true;

--- a/assets/js/Components/NcdumpDialog/detectZarrStore.js
+++ b/assets/js/Components/NcdumpDialog/detectZarrStore.js
@@ -3,6 +3,20 @@ import { useState, useEffect } from "react";
 import { getTokenFromCookie, normalizeUrl } from "../../utils";
 
 /**
+ * True when `base` resolves to the same origin as the running app.
+ * Relative paths (Freva API) are same-origin; absolute external store
+ * URLs (S3/minio) are not.
+ */
+function isSameOrigin(base) {
+  try {
+    return new URL(base, window.location.origin).origin === window.location.origin;
+  } catch {
+    // If it does not parse as a URL, treat it as a relative/same-origin path.
+    return true;
+  }
+}
+
+/**
  * Checks whether a URL already points to a zarr store by probing
  * .zmetadata (v2 consolidated) and zarr.json (v2/v3).
  *
@@ -21,7 +35,11 @@ export async function detectZarrStore(url) {
   // percent-encoded one slips through, decode it here so the fetch
   // below is not treated as a relative path by the browser.
   const base = normalizeUrl(url).replace(/\/$/, "");
-  const token = getTokenFromCookie();
+  // Only attach the Freva auth token for same-origin Freva API requests.
+  // External object stores (e.g. the S3/minio buckets)
+  // interpret an unexpected `Authorization` header as an AWS credential and
+  // reject the request with 403
+  const token = isSameOrigin(base) ? getTokenFromCookie() : null;
   const headers = token
     ? { Authorization: `${token.token_type} ${token.access_token}` }
     : {};

--- a/assets/js/Components/NcdumpDialog/useHtmlMetadata.js
+++ b/assets/js/Components/NcdumpDialog/useHtmlMetadata.js
@@ -230,7 +230,18 @@ async function openDatasetMeta(url) {
   // Defensive: a percent-encoded URL would be treated as a relative path
   // by the browser. Normalize so the fetch lands at the real origin.
   const base = normalizeUrl(url).replace(/\/$/, "");
-  const token = getTokenFromCookie();
+  // only send the Freva token to same-origin Freva API endpoints.
+  // Sending it to an external S3/minio store makes that store 403 the
+  // otherwise-anonymous request, so the client-side metadata render
+  // fails and we get bounced to the data-loader.
+  let sameOrigin = true;
+  try {
+    sameOrigin =
+      new URL(base, window.location.origin).origin === window.location.origin;
+  } catch {
+    sameOrigin = true;
+  }
+  const token = sameOrigin ? getTokenFromCookie() : null;
   const headers = token
     ? { Authorization: `${token.token_type} ${token.access_token}` }
     : {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evaluation_system_web",
-  "version": "2606.0.4",
+  "version": "2607.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "evaluation_system_web",
-      "version": "2606.0.4",
+      "version": "2607.0.0",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^2.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evaluation_system_web",
-  "version": "2606.0.4",
+  "version": "2607.0.0",
   "description": "React-bits of the freva-web interface. The react-parts of the web interface include the plugin-selection, the data-browser and the result-browser",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Inspector internal functions were sending the Freva bearer token as an `Authorization` header when probing `.zmetadata` /
`zarr.json` even for all cases even externals. The issue raised, when the store lives on a third-party object store, S3 gateways interprets that header as an AWS credential and returns 403, even though the object is publicly readable anonymously. This PR is going to fix the bug.