### PR TITLE
fix(chatbot): prevent unnecessary rerenders during response streaming

### DIFF
--- a/assets/js/Containers/FrevaGPT/components/SidePanel/SidePanel.js
+++ b/assets/js/Containers/FrevaGPT/components/SidePanel/SidePanel.js
@@ -101,4 +101,4 @@ SidePanel.propTypes = {
   setShowThreadHistory: PropTypes.func,
 };
 
-export default SidePanel;
+export default React.memo(SidePanel);

--- a/assets/js/Containers/FrevaGPT/index.js
+++ b/assets/js/Containers/FrevaGPT/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useSelector, useDispatch } from "react-redux";
 
 import { Container, Row, Col, Spinner } from "react-bootstrap";
@@ -70,6 +70,12 @@ function FrevaGPT() {
   const botModel = useSelector((state) => state.frevaGPTReducer.botModel);
 
   const dispatch = useDispatch();
+  const handleEditChatRef = useRef();
+  const stableHandleEditChat = useCallback(
+    (...args) => handleEditChatRef.current(...args),
+    []
+  );
+  handleEditChatRef.current = handleEditChat;
 
   /*-----------------------------------------------------------------------------------------------
   *
@@ -460,7 +466,7 @@ function FrevaGPT() {
         >
           <Row className="overflow-auto position-relative" id="chatContainer">
             <Col md={12}>
-              <ChatBlock onEditInput={handleEditChat} />
+              <ChatBlock onEditInput={stableHandleEditChat} />
 
               <PendingAnswerComponent
                 content={dynamicAnswer}


### PR DESCRIPTION
- Memoize the thread-history side panel
- Pass a stable edit callback to the chat history
- Preserve access to the latest edit handler without stale state

This drastically reduces the number of rerenders, let's see if it is enough